### PR TITLE
Fix travis build & new rule: constant names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: crystal
-after_script:
-  - make build
-  - ./bin/ameba
+script:
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ clean:
 install: build
 	mkdir -p $(PREFIX)/bin
 	cp ./bin/ameba $(PREFIX)/bin
+test: build
+	$(CRYSTAL_BIN) spec
+	./bin/ameba

--- a/spec/ameba/rules/constant_names_spec.cr
+++ b/spec/ameba/rules/constant_names_spec.cr
@@ -1,0 +1,51 @@
+require "../../spec_helper"
+
+module Ameba
+  subject = Rules::ConstantNames.new
+
+  private def it_reports_constant(content, expected)
+    it "reports constant name #{expected}" do
+      s = Source.new content
+      Rules::ConstantNames.new.catch(s).should_not be_valid
+      s.errors.first.message.should contain expected
+    end
+  end
+
+  describe Rules::ConstantNames do
+    it "passes if type names are screaming-cased" do
+      s = Source.new %(
+        LUCKY_NUMBERS     = [3, 7, 11]
+        DOCUMENTATION_URL = "http://crystal-lang.org/docs"
+
+        Int32
+
+        s : String = "str"
+
+        def works(n : Int32)
+        end
+
+        a = 1
+        myVar = 2
+        m_var = 3
+      )
+      subject.catch(s).should be_valid
+    end
+
+    it_reports_constant "MyBadConstant=1", "MYBADCONSTANT"
+    it_reports_constant "Wrong_NAME=2", "WRONG_NAME"
+    it_reports_constant "Wrong_Name=3", "WRONG_NAME"
+
+    it "reports rule, pos and message" do
+      s = Source.new %(
+        Const = 1
+      )
+      subject.catch(s).should_not be_valid
+      error = s.errors.first
+      error.rule.should_not be_nil
+      error.pos.should eq 2
+      error.message.should eq(
+        "Constant name should be screaming-cased: CONST, not Const"
+      )
+    end
+  end
+end

--- a/src/ameba/ast/traverse.cr
+++ b/src/ameba/ast/traverse.cr
@@ -3,6 +3,7 @@ require "compiler/crystal/syntax/*"
 module Ameba::AST
   NODE_VISITORS = [
     Alias,
+    Assign,
     Call,
     Case,
     ClassDef,

--- a/src/ameba/rules/constant_names.cr
+++ b/src/ameba/rules/constant_names.cr
@@ -1,0 +1,33 @@
+module Ameba::Rules
+  # A rule that enforces constant names to be in screaming case.
+  #
+  # For example, these constant names are considered valid:
+  #
+  # ```
+  # LUCKY_NUMBERS     = [3, 7, 11]
+  # DOCUMENTATION_URL = "http://crystal-lang.org/docs"
+  # ```
+  #
+  # And these are invalid names:
+  #
+  # ```
+  # MyBadConstant = 1
+  # Wrong_NAME    = 2
+  # ```
+  #
+  struct ConstantNames < Rule
+    def test(source)
+      AST::AssignVisitor.new self, source
+    end
+
+    def test(source, node : Crystal::Assign)
+      if (target = node.target).is_a? Crystal::Path
+        name = target.names.first
+        return if (expected = name.upcase) == name
+
+        source.error self, node.location.try &.line_number,
+          "Constant name should be screaming-cased: #{expected}, not #{name}"
+      end
+    end
+  end
+end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -15,6 +15,4 @@ OptionParser.parse(ARGV) do |parser|
   end
 end
 
-sources = Ameba.run
-failed = sources.any? { |s| !s.valid? }
-exit(-1) if failed
+exit(1) unless Ameba.run.all? &.valid?


### PR DESCRIPTION
  A rule that enforces constant names to be in screaming case. Following [Coding style conventions](https://crystal-lang.org/docs/conventions/coding_style.html).
  
  For example, these constant names are considered valid:
  
  ```crystal
  LUCKY_NUMBERS     = [3, 7, 11]
  DOCUMENTATION_URL = "http://crystal-lang.org/docs"
  ```
  
  And these are invalid names:
  
  ```crystal
  MyBadConstant = 1
  Wrong_NAME    = 2
  ```
  
