### PR TITLE
Performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,22 +67,21 @@ your logic to detect a problem:
 ```crystal
 struct DebuggerStatement < Rule
   # This is a required method to be implemented by the rule.
-  # Source will pass here. If rule finds an issue in this source,
-  # it adds an error: 
+  # Source will be passed here. If rule finds an issue in this source,
+  # it reports an error: 
   # 
   #   source.error rule, line_number, message
   #
   def test(source)
     # This line deletegates verification to a particular AST visitor.
-    AST::CallVisitor.new self, source
+    AST::Visitor.new self, source
   end
 
-  # This method is called once our visitor finds a required node.
-  # 
-  # It reports an error, once there is `debugger` method call
-  # without arguments and a receiver. That's it, somebody forgot
-  # to remove debugger statement.
+  # This method is called once the visitor finds a required node.
   def test(source, node : Crystal::Call)
+    # It reports an error, if there is `debugger` method call
+    # without arguments and a receiver. That's it, somebody forgot
+    # to remove a debugger statement.
     return unless node.name == "debugger" && node.args.empty? && node.obj.nil?
 
     source.error self, node.location.try &.line_number,

--- a/spec/ameba/ast/traverse_spec.cr
+++ b/spec/ameba/ast/traverse_spec.cr
@@ -8,7 +8,7 @@ module Ameba::AST
     {% for name in NODE_VISITORS %}
       describe "{{name}}" do
         it "allow to visit {{name}} node" do
-          visitor = {{name}}Visitor.new rule, source
+          visitor = Visitor.new rule, source
           nodes = Crystal::Parser.new("").parse
           nodes.accept visitor
         end

--- a/src/ameba/ast/traverse.cr
+++ b/src/ameba/ast/traverse.cr
@@ -19,26 +19,23 @@ module Ameba::AST
     Var,
   ]
 
-  abstract class Visitor < Crystal::Visitor
+  class Visitor < Crystal::Visitor
     @rule : Rule
     @source : Source
 
     def initialize(@rule, @source)
-      parser = Crystal::Parser.new(@source.content)
-      parser.filename = @source.path
-      parser.parse.accept self
+      @source.ast.accept self
     end
 
     def visit(node : Crystal::ASTNode)
       true
     end
-  end
 
-  {% for name in NODE_VISITORS %}
-    class {{name}}Visitor < Visitor
+    {% for name in NODE_VISITORS %}
       def visit(node : Crystal::{{name}})
         @rule.test @source, node
+        true
       end
-    end
-  {% end %}
+    {% end %}
+  end
 end

--- a/src/ameba/rule.cr
+++ b/src/ameba/rule.cr
@@ -3,7 +3,7 @@ module Ameba
     abstract def test(source : Source)
 
     def test(source : Source, node : Crystal::ASTNode)
-      raise "Unimplemented"
+      # can't be abstract
     end
 
     def catch(source : Source)

--- a/src/ameba/rules/comparison_to_boolean.cr
+++ b/src/ameba/rules/comparison_to_boolean.cr
@@ -14,7 +14,7 @@ module Ameba::Rules
   #
   struct ComparisonToBoolean < Rule
     def test(source)
-      AST::CallVisitor.new self, source
+      AST::Visitor.new self, source
     end
 
     def test(source, node : Crystal::Call)

--- a/src/ameba/rules/constant_names.cr
+++ b/src/ameba/rules/constant_names.cr
@@ -17,7 +17,7 @@ module Ameba::Rules
   #
   struct ConstantNames < Rule
     def test(source)
-      AST::AssignVisitor.new self, source
+      AST::Visitor.new self, source
     end
 
     def test(source, node : Crystal::Assign)

--- a/src/ameba/rules/debugger_statement.cr
+++ b/src/ameba/rules/debugger_statement.cr
@@ -6,7 +6,7 @@ module Ameba::Rules
   #
   struct DebuggerStatement < Rule
     def test(source)
-      AST::CallVisitor.new self, source
+      AST::Visitor.new self, source
     end
 
     def test(source, node : Crystal::Call)

--- a/src/ameba/rules/literal_in_condition.cr
+++ b/src/ameba/rules/literal_in_condition.cr
@@ -17,9 +17,7 @@ module Ameba::Rules
     include AST::Util
 
     def test(source)
-      AST::IfVisitor.new self, source
-      AST::UnlessVisitor.new self, source
-      AST::CaseVisitor.new self, source
+      AST::Visitor.new self, source
     end
 
     def check_node(source, node)

--- a/src/ameba/rules/literal_in_interpolation.cr
+++ b/src/ameba/rules/literal_in_interpolation.cr
@@ -13,7 +13,7 @@ module Ameba::Rules
     include AST::Util
 
     def test(source)
-      AST::StringInterpolationVisitor.new self, source
+      AST::Visitor.new self, source
     end
 
     def test(source, node : Crystal::StringInterpolation)

--- a/src/ameba/rules/method_names.cr
+++ b/src/ameba/rules/method_names.cr
@@ -32,7 +32,7 @@ module Ameba::Rules
   # ```
   struct MethodNames < Rule
     def test(source)
-      AST::DefVisitor.new self, source
+      AST::Visitor.new self, source
     end
 
     def test(source, node : Crystal::Def)

--- a/src/ameba/rules/negated_conditions_in_unless.cr
+++ b/src/ameba/rules/negated_conditions_in_unless.cr
@@ -22,7 +22,7 @@ module Ameba::Rules
   #
   struct NegatedConditionsInUnless < Rule
     def test(source)
-      AST::UnlessVisitor.new self, source
+      AST::Visitor.new self, source
     end
 
     def test(source, node : Crystal::Unless)

--- a/src/ameba/rules/predicate_name.cr
+++ b/src/ameba/rules/predicate_name.cr
@@ -24,7 +24,7 @@ module Ameba::Rules
   #
   struct PredicateName < Rule
     def test(source)
-      AST::DefVisitor.new self, source
+      AST::Visitor.new self, source
     end
 
     def test(source, node : Crystal::Def)

--- a/src/ameba/rules/type_names.cr
+++ b/src/ameba/rules/type_names.cr
@@ -47,13 +47,7 @@ module Ameba::Rules
   #
   struct TypeNames < Rule
     def test(source)
-      [
-        AST::ClassDefVisitor,
-        AST::EnumDefVisitor,
-        AST::ModuleDefVisitor,
-        AST::AliasVisitor,
-        AST::LibDefVisitor,
-      ].each(&.new self, source)
+      AST::Visitor.new self, source
     end
 
     private def check_node(source, node)

--- a/src/ameba/rules/unless_else.cr
+++ b/src/ameba/rules/unless_else.cr
@@ -38,7 +38,7 @@ module Ameba::Rules
   #
   struct UnlessElse < Rule
     def test(source)
-      AST::UnlessVisitor.new self, source
+      AST::Visitor.new self, source
     end
 
     def test(source, node : Crystal::Unless)

--- a/src/ameba/rules/variable_names.cr
+++ b/src/ameba/rules/variable_names.cr
@@ -26,11 +26,7 @@ module Ameba::Rules
   #
   struct VariableNames < Rule
     def test(source)
-      [
-        AST::VarVisitor,
-        AST::InstanceVarVisitor,
-        AST::ClassVarVisitor,
-      ].each &.new(self, source)
+      AST::Visitor.new self, source
     end
 
     private def check_node(source, node)

--- a/src/ameba/source.cr
+++ b/src/ameba/source.cr
@@ -15,6 +15,7 @@ module Ameba
     getter errors = [] of Error
     getter path : String?
     getter content : String
+    getter ast : Crystal::ASTNode?
 
     def initialize(@content : String, @path = nil)
     end
@@ -29,6 +30,13 @@ module Ameba
 
     def lines
       @lines ||= @content.split("\n")
+    end
+
+    def ast
+      @ast ||=
+        Crystal::Parser.new(content)
+                       .tap { |parser| parser.filename = @path }
+                       .parse
     end
   end
 end


### PR DESCRIPTION
Two main improvements:

1. Cache parsed AST in a Source. So Parser will parse content only once.
2. Use one unified visitor with multiple callbacks instead of multiple visitors to traverse AST.

This improves performance significantly, for example running it on a Crystal repository now takes ~1 second, instead of 6 seconds that it was before (1179 files).

Benchmarks:

```
== Compare:
  1 source  12.69k (  78.8µs) (± 1.12%)       fastest
 3 sources   6.21k (161.15µs) (± 1.34%)  2.04× slower
 5 sources   1.87k (533.92µs) (± 1.24%)  6.78× slower
10 sources 869.12  (  1.15ms) (± 2.20%) 14.60× slower
20 sources  487.1  (  2.05ms) (± 1.12%) 26.05× slower
30 sources 361.01  (  2.77ms) (± 1.06%) 35.15× slower
40 sources 361.28  (  2.77ms) (± 0.86%) 35.12× slower
== Measure:
  0.010000   0.020000   0.030000 (  0.018274)
```

in comparison to master:

```
== Compare:
  1 source    1.2k (832.79µs) (± 2.44%)       fastest
 3 sources 697.94  (  1.43ms) (± 2.08%)  1.72× slower
 5 sources 204.45  (  4.89ms) (± 5.59%)  5.87× slower
10 sources  103.1  (   9.7ms) (± 3.42%) 11.65× slower
20 sources  61.21  ( 16.34ms) (± 1.62%) 19.62× slower
30 sources  47.33  ( 21.13ms) (± 1.53%) 25.37× slower
40 sources  47.56  ( 21.03ms) (± 1.16%) 25.25× slower
== Measure:
  0.060000   0.040000   0.100000 (  0.073773)
```