### PR TITLE
YAML config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Or just compile it from sources `make install`.
 
 ## Usage
 
-Run `ameba` binary to catch code issues within you project:
+Run `ameba` binary within your project directory to catch code issues:
 
 ```sh
 $ ameba
@@ -62,6 +62,12 @@ Finished in 10.53 milliseconds
 
 52 inspected, 3 failures.
 ```
+
+## Configuration
+
+It is possible to configure or even disable specific rules using YAML configuration file.
+By default Ameba is looking for `.ameba.yml` in a project root directory.
+Copy and adjust [existed example](config/ameba.yml).
 
 ## Write a new Rule
 

--- a/bench/check_sources.cr
+++ b/bench/check_sources.cr
@@ -1,7 +1,7 @@
 require "../src/ameba"
 require "benchmark"
 
-private def get_sources(n)
+private def get_files(n)
   Dir["src/**/*.cr"].first(n)
 end
 
@@ -16,10 +16,11 @@ Benchmark.ips do |x|
     30,
     40,
   ].each do |n|
-    sources = get_sources(n)
-    formatter = Ameba::Formatter::BaseFormatter.new
+    config = Ameba::Config.load
+    config.formatter = Ameba::Formatter::BaseFormatter.new
+    config.files = get_files(n)
     s = n == 1 ? "" : "s"
-    x.report("#{n} source#{s}") { Ameba.run sources, formatter }
+    x.report("#{n} source#{s}") { Ameba.run config }
   end
 end
 

--- a/config/ameba.yml
+++ b/config/ameba.yml
@@ -1,0 +1,67 @@
+ComaprisonToBoolean:
+  # Disallows comparison to booleans in conditions.
+  Enabled: true
+
+ConstantNames:
+  # Enforces constant names to be in a screaming case.
+  Enabled: true
+
+DebuggerStatement:
+  # Disallows calls to debugger.
+  Enabled: true
+
+EmptyExpression:
+  # Disallows empty expressions.
+  Enabled: true
+
+LargeNumbers:
+  # A rule that disallows usage of large numbers without underscore.
+  Enabled: true
+
+LineLength:
+  # Disallows lines longer that MaxLength number of symbols.
+  Enabled: true
+  MaxLength: 80
+
+LiteralInCondition:
+  # Disallows useless conditional statements that contain a literal in place
+  # of a variable or predicate function.
+  Enabled: true
+
+LiteralInInterpolation:
+  # Disallows useless string interpolations that contain a literal value
+  # instead of a variable or function.
+  Enabled: true
+
+MethodNames:
+  # Enforces method names to be in the underscored case.
+  Enabled: true
+
+NegatedConditionsInUnless:
+  # Disallows negated conditions in unless.
+  Enabled: true
+
+PredicateName:
+  # Disallows tautological predicate names, meaning those that start with
+  # the prefix `has_` or the prefix `is_`.
+  Enabled: true
+
+TrailingBlankLines:
+  # Disallows trailing blank lines at the end of the source file.
+  Enabled: true
+
+TrailingWhitespace:
+  # Disallows trailing whitespaces.
+  Enabled: true
+
+TypeNames:
+  # Enforces type names in a camelcase manner.
+  Enabled: true
+
+UnlessElse:
+  # Disallows the use of an `else` block with `unless`.
+  Enabled: true
+
+VariableNames:
+  # Enforces variable names to be in the underscored case.
+  Enabled: true

--- a/spec/ameba/config_spec.cr
+++ b/spec/ameba/config_spec.cr
@@ -1,0 +1,58 @@
+require "../spec_helper"
+
+module Ameba
+  describe Config do
+    config_sample = "config/ameba.yml"
+
+    describe ".load" do
+      it "loads custom config" do
+        config = Config.load config_sample
+        config.should_not be_nil
+        config.files.should_not be_nil
+        config.formatter.should_not be_nil
+      end
+
+      it "loads default config" do
+        config = Config.load
+        config.should_not be_nil
+        config.files.should_not be_nil
+        config.formatter.should_not be_nil
+      end
+    end
+
+    describe "#files, #files=" do
+      config = Config.load config_sample
+
+      it "holds source files" do
+        config.files.should contain "spec/ameba/config_spec.cr"
+      end
+
+      it "allows to set files" do
+        config.files = ["file.cr"]
+        config.files.should eq ["file.cr"]
+      end
+    end
+
+    describe "#formatter, formatter=" do
+      config = Config.load config_sample
+      formatter = DummyFormatter.new
+
+      it "contains default formatter" do
+        config.formatter.should_not be_nil
+      end
+
+      it "allows to set formatter" do
+        config.formatter = formatter
+        config.formatter.should eq formatter
+      end
+    end
+
+    describe "#subconfig" do
+      it "returns a specific subconfig" do
+        config = Config.load config_sample
+        config.subconfig("NoSuchConfig").should be_nil
+        config.subconfig(Rule::LineLength.new.name).should_not be_nil
+      end
+    end
+  end
+end

--- a/spec/ameba/runner_spec.cr
+++ b/spec/ameba/runner_spec.cr
@@ -1,0 +1,58 @@
+require "../spec_helper"
+
+module Ameba
+  private def runner(files = [__FILE__], formatter = DummyFormatter.new)
+    config = Config.load "config/ameba.yml"
+    config.formatter = formatter
+    config.files = files
+
+    Runner.new(config)
+  end
+
+  describe Runner do
+    formatter = DummyFormatter.new
+
+    describe "#run" do
+      it "returns self" do
+        runner.run.should_not be_nil
+      end
+
+      it "calls started callback" do
+        runner(formatter: formatter).run
+        formatter.started_sources.should_not be_nil
+      end
+
+      it "calls finished callback" do
+        runner(formatter: formatter).run
+        formatter.finished_sources.should_not be_nil
+      end
+
+      it "calls source_started callback" do
+        runner(formatter: formatter).run
+        formatter.started_source.should_not be_nil
+      end
+
+      it "calls source_finished callback" do
+        runner(formatter: formatter).run
+        formatter.finished_source.should_not be_nil
+      end
+    end
+
+    describe "#success?" do
+      it "returns true if runner has not been run" do
+        runner.success?.should be_true
+      end
+
+      it "returns true if all sources are valid" do
+        runner.run.success?.should be_true
+      end
+
+      it "returns false if there are invalid sources" do
+        s = Source.new %q(
+          WrongConstant = 5
+        )
+        Runner.new([s], formatter).run.success?.should be_false
+      end
+    end
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -7,6 +7,29 @@ module Ameba
     end
   end
 
+  class DummyFormatter < Formatter::BaseFormatter
+    property started_sources : Array(Source)?
+    property finished_sources : Array(Source)?
+    property started_source : Source?
+    property finished_source : Source?
+
+    def started(sources)
+      @started_sources = sources
+    end
+
+    def source_finished(source : Source)
+      @started_source = source
+    end
+
+    def source_started(source : Source)
+      @finished_source = source
+    end
+
+    def finished(sources)
+      @finished_sources = sources
+    end
+  end
+
   struct BeValidExpectation
     def match(source)
       source.valid?

--- a/src/ameba.cr
+++ b/src/ameba.cr
@@ -6,26 +6,7 @@ require "./ameba/formatter/*"
 module Ameba
   extend self
 
-  def run(formatter = Formatter::BaseFormatter.new)
-    run Dir["**/*.cr"].reject(&.starts_with? "lib/"), formatter
-  end
-
-  def run(files, formatter : Formatter::BaseFormatter)
-    sources = files.map { |path| Source.new(File.read(path), path) }
-
-    formatter.started sources
-    sources.each do |source|
-      formatter.source_started source
-      catch(source)
-      formatter.source_finished source
-    end
-    formatter.finished sources
-    sources
-  end
-
-  def catch(source : Source)
-    Rule.rules.each do |rule|
-      rule.new.test(source)
-    end
+  def run(config = Config.load)
+    Runner.new(config).run
   end
 end

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -1,0 +1,69 @@
+require "yaml"
+
+class Ameba::Config
+  setter formatter : Formatter::BaseFormatter?
+  setter files : Array(String)?
+
+  def initialize(@config : YAML::Any)
+  end
+
+  def self.load(path = ".ameba.yml")
+    content = (path && File.exists? path) ? File.read path : "{}"
+    Config.new YAML.parse(content)
+  end
+
+  def files
+    @files ||= default_files
+  end
+
+  def formatter
+    @formatter ||= default_formatter
+  end
+
+  def subconfig(name)
+    @config[name]?
+  end
+
+  private def default_files
+    Dir["**/*.cr"].reject(&.starts_with? "lib/")
+  end
+
+  private def default_formatter
+    Formatter::DotFormatter.new
+  end
+
+  module Rule
+    getter config : YAML::Any?
+
+    macro prop(assign)
+      # Rule configuration property.
+      def {{assign.target}}
+        {% prop_name = assign.target.id.camelcase.gsub(/\?/, "") %}
+
+        {% if assign.value.is_a? NumberLiteral %}
+          int_prop "{{prop_name}}", {{assign.value}}
+        {% elsif assign.value.is_a? BoolLiteral %}
+          bool_prop "{{prop_name}}", {{assign.value}}
+        {% elsif assign.value.is_a? StringLiteral %}
+          str_prop "{{prop_name}}", {{assign.value}}
+        {% end %}
+      end
+    end
+
+    def initialize(config = nil)
+      @config = config.try &.subconfig(name)
+    end
+
+    protected def int_prop(name, default : Number)
+      str_prop(name, default).to_i
+    end
+
+    protected def bool_prop(name, default : Bool)
+      str_prop(name, default.to_s) == "true"
+    end
+
+    protected def str_prop(name, default)
+      config.try &.[name]?.try &.as_s || default
+    end
+  end
+end

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -12,6 +12,10 @@ class Ameba::Config
     Config.new YAML.parse(content)
   end
 
+  def self.load(path : Nil)
+    self.load
+  end
+
   def files
     @files ||= default_files
   end

--- a/src/ameba/rule/base.cr
+++ b/src/ameba/rule/base.cr
@@ -1,6 +1,10 @@
 module Ameba::Rule
   abstract struct Base
+    include Config::Rule
+
     abstract def test(source : Source)
+
+    prop enabled? = true
 
     def test(source : Source, node : Crystal::ASTNode)
       # can't be abstract

--- a/src/ameba/rule/comparison_to_boolean.cr
+++ b/src/ameba/rule/comparison_to_boolean.cr
@@ -8,9 +8,17 @@ module Ameba::Rule
   # bar != false
   # false === baz
   # ```
+  #
   # This is because these expressions evaluate to `true` or `false`, so you
   # could get the same result by using either the variable directly,
   # or negating the variable.
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # ComparisonToBoolean:
+  #   Enabled: true
+  # ```
   #
   struct ComparisonToBoolean < Base
     def test(source)

--- a/src/ameba/rule/constant_names.cr
+++ b/src/ameba/rule/constant_names.cr
@@ -15,6 +15,13 @@ module Ameba::Rule
   # Wrong_NAME    = 2
   # ```
   #
+  # YAML configuration example:
+  #
+  # ```
+  # ConstantNames:
+  #   Enabled: true
+  # ```
+  #
   struct ConstantNames < Base
     def test(source)
       AST::Visitor.new self, source

--- a/src/ameba/rule/debugger_statement.cr
+++ b/src/ameba/rule/debugger_statement.cr
@@ -4,6 +4,13 @@ module Ameba::Rule
   # This is because we don't want debugger breakpoints accidentally being
   # committed into our codebase.
   #
+  # YAML configuration example:
+  #
+  # ```
+  # DebuggerStatement:
+  #   Enabled: true
+  # ```
+  #
   struct DebuggerStatement < Base
     def test(source)
       AST::Visitor.new self, source

--- a/src/ameba/rule/empty_expression.cr
+++ b/src/ameba/rule/empty_expression.cr
@@ -21,6 +21,13 @@ module Ameba::Rule
   # end
   # ```
   #
+  # YAML configuration example:
+  #
+  # ```
+  # EmptyExpression:
+  #   Enabled: true
+  # ```
+  #
   struct EmptyExpression < Base
     include AST::Util
 

--- a/src/ameba/rule/large_numbers.cr
+++ b/src/ameba/rule/large_numbers.cr
@@ -19,6 +19,13 @@ module Ameba::Rule
   # 5.123_45
   # ```
   #
+  # YAML configuration example:
+  #
+  # ```
+  # LargeNumbers:
+  #   Enabled: true
+  # ```
+  #
   struct LargeNumbers < Base
     def test(source)
       Tokenizer.new(source).run do |token|

--- a/src/ameba/rule/line_length.cr
+++ b/src/ameba/rule/line_length.cr
@@ -1,10 +1,19 @@
 module Ameba::Rule
-  # A rule that disallows lines longer than 80 symbols.
+  # A rule that disallows lines longer than `max_length` number of symbols.
   #
+  # YAML configuration example:
+  #
+  # ```
+  # LineLength:
+  #   Enabled: true
+  #   MaxLength: 100
+  # ```
   struct LineLength < Base
+    prop max_length = 80
+
     def test(source)
       source.lines.each_with_index do |line, index|
-        next unless line.size > 80
+        next unless line.size > max_length
 
         source.error self, source.location(index + 1, line.size),
           "Line too long"

--- a/src/ameba/rule/line_length.cr
+++ b/src/ameba/rule/line_length.cr
@@ -8,6 +8,7 @@ module Ameba::Rule
   #   Enabled: true
   #   MaxLength: 100
   # ```
+  #
   struct LineLength < Base
     prop max_length = 80
 

--- a/src/ameba/rule/literal_in_condition.cr
+++ b/src/ameba/rule/literal_in_condition.cr
@@ -13,6 +13,13 @@ module Ameba::Rule
   # end
   # ```
   #
+  # YAML configuration example:
+  #
+  # ```
+  # LiteralInCondition:
+  #   Enabled: true
+  # ```
+  #
   struct LiteralInCondition < Base
     include AST::Util
 

--- a/src/ameba/rule/literal_in_interpolation.cr
+++ b/src/ameba/rule/literal_in_interpolation.cr
@@ -9,6 +9,13 @@ module Ameba::Rule
   # "There are #{4} cats"
   # ```
   #
+  # YAML configuration example:
+  #
+  # ```
+  # LiteralInInterpolation
+  #   Enabled: true
+  # ```
+  #
   struct LiteralInInterpolation < Base
     include AST::Util
 

--- a/src/ameba/rule/method_names.cr
+++ b/src/ameba/rule/method_names.cr
@@ -30,6 +30,14 @@ module Ameba::Rule
   #   end
   # end
   # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # MethodNames:
+  #   Enabled: true
+  # ```
+  #
   struct MethodNames < Base
     def test(source)
       AST::Visitor.new self, source

--- a/src/ameba/rule/negated_conditions_in_unless.cr
+++ b/src/ameba/rule/negated_conditions_in_unless.cr
@@ -20,6 +20,13 @@ module Ameba::Rule
   # It is pretty difficult to wrap your head around a block of code
   # that is executed if a negated condition is NOT met.
   #
+  # YAML configuration example:
+  #
+  # ```
+  # NegatedConditionsInUnless:
+  #   Enabled: true
+  # ```
+  #
   struct NegatedConditionsInUnless < Base
     def test(source)
       AST::Visitor.new self, source

--- a/src/ameba/rule/predicate_name.cr
+++ b/src/ameba/rule/predicate_name.cr
@@ -22,6 +22,13 @@ module Ameba::Rule
   # end
   # ```
   #
+  # YAML configuration example:
+  #
+  # ```
+  # PredicateName:
+  #   Enabled: true
+  # ```
+  #
   struct PredicateName < Base
     def test(source)
       AST::Visitor.new self, source

--- a/src/ameba/rule/trailing_blank_lines.cr
+++ b/src/ameba/rule/trailing_blank_lines.cr
@@ -1,6 +1,13 @@
 module Ameba::Rule
   # A rule that disallows trailing blank lines at the end of the source file.
   #
+  # YAML configuration example:
+  #
+  # ```
+  # TrailingBlankLines:
+  #   Enabled: true
+  # ```
+  #
   struct TrailingBlankLines < Base
     def test(source)
       if source.lines.size > 1 && source.lines[-2, 2].join.strip.empty?

--- a/src/ameba/rule/trailing_whitespace.cr
+++ b/src/ameba/rule/trailing_whitespace.cr
@@ -1,6 +1,13 @@
 module Ameba::Rule
   # A rule that disallows trailing whitespaces.
   #
+  # YAML configuration example:
+  #
+  # ```
+  # TrailingWhitespace:
+  #   Enabled: true
+  # ```
+  #
   struct TrailingWhitespace < Base
     def test(source)
       source.lines.each_with_index do |line, index|

--- a/src/ameba/rule/type_names.cr
+++ b/src/ameba/rule/type_names.cr
@@ -45,6 +45,13 @@ module Ameba::Rule
   # end
   # ```
   #
+  # YAML configuration example:
+  #
+  # ```
+  # TypeNames:
+  #   Enabled: true
+  # ```
+  #
   struct TypeNames < Base
     def test(source)
       AST::Visitor.new self, source

--- a/src/ameba/rule/unless_else.cr
+++ b/src/ameba/rule/unless_else.cr
@@ -36,6 +36,13 @@ module Ameba::Rule
   # end
   # ```
   #
+  # YAML configuration example:
+  #
+  # ```
+  # UnlessElse:
+  #   Enabled: true
+  # ```
+  #
   struct UnlessElse < Base
     def test(source)
       AST::Visitor.new self, source

--- a/src/ameba/rule/variable_names.cr
+++ b/src/ameba/rule/variable_names.cr
@@ -24,6 +24,13 @@ module Ameba::Rule
   # wrong_Name = 2
   # ```
   #
+  # YAML configuration example:
+  #
+  # ```
+  # VariableNames:
+  #   Enabled: true
+  # ```
+  #
   struct VariableNames < Base
     def test(source)
       AST::Visitor.new self, source

--- a/src/ameba/runner.cr
+++ b/src/ameba/runner.cr
@@ -1,0 +1,49 @@
+module Ameba
+  class Runner
+    @rules : Array(Rule::Base)
+    @sources : Array(Source)
+    @formatter : Formatter::BaseFormatter
+
+    def initialize(config : Config)
+      @rules = load_rules(config)
+      @sources = load_sources(config)
+      @formatter = config.formatter
+    end
+
+    def run
+      @formatter.started @sources
+      @sources.each do |source|
+        @formatter.source_started source
+
+        @rules.each &.test(source)
+
+        @formatter.source_finished source
+      end
+      self
+    ensure
+      @formatter.finished @sources
+    end
+
+    def success?
+      @sources.all? &.valid?
+    end
+
+    def test_source(source)
+      @formatter.source_started source
+      @rules.each &.test(source)
+    ensure
+      @formatter.source_finished source
+    end
+
+    private def load_sources(config)
+      config.files
+            .map { |wildcard| Dir[wildcard] }
+            .flatten
+            .map { |path| Source.new File.read(path), path }
+    end
+
+    private def load_rules(config)
+      Rule.rules.map { |r| r.new config }.select &.enabled?
+    end
+  end
+end

--- a/src/ameba/runner.cr
+++ b/src/ameba/runner.cr
@@ -10,6 +10,10 @@ module Ameba
       @formatter = config.formatter
     end
 
+    def initialize(@sources, @formatter)
+      @rules = load_rules nil
+    end
+
     def run
       @formatter.started @sources
       @sources.each do |source|
@@ -26,13 +30,6 @@ module Ameba
 
     def success?
       @sources.all? &.valid?
-    end
-
-    def test_source(source)
-      @formatter.source_started source
-      @rules.each &.test(source)
-    ensure
-      @formatter.source_finished source
     end
 
     private def load_sources(config)

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -1,10 +1,10 @@
 require "option_parser"
 require "./ameba"
 
-formatter = Ameba::Formatter::DotFormatter
+files, formatter, config_path = nil, nil, nil
 
 OptionParser.parse(ARGV) do |parser|
-  parser.banner = "Usage: ameba [options]"
+  parser.banner = "Usage: ameba [options] [file1 file2 ...]"
 
   parser.on("-v", "--version", "Print version") do
     puts Ameba::VERSION
@@ -17,10 +17,23 @@ OptionParser.parse(ARGV) do |parser|
   end
 
   parser.on("-s", "--silent", "Disable output") do
-    formatter = Ameba::Formatter::BaseFormatter
+    formatter = Ameba::Formatter::BaseFormatter.new
+  end
+
+  # parser.on("-f FORMATTER", "--format FORMATTER", "Specify formatter") do |f|
+  # end
+
+  parser.on("-c PATH", "--config PATH", "Specify configuration file") do |f|
+    config_path = f
+  end
+
+  parser.unknown_args do |f|
+    files = f if f.any?
   end
 end
 
-files = Dir["**/*.cr"]
+config = Ameba::Config.load config_path
+config.formatter = formatter
+config.files = files
 
-exit(1) unless Ameba.run(files, formatter.new).all? &.valid?
+exit(1) unless Ameba.run(config).success?


### PR DESCRIPTION
This PR prepares the following additions:

- [x] Ameba runner
- [x] YAML config loader
- [x] Macro for Rule configuration properties
- [x] YAML documented properties
- [x] Sample configuration file
- [x] CLI args

So now it is possible to define rule properties using `prop` macro:

```crystal
struct SuperRule < Base
  prop max_length = 80
  prop enabled? = true
  prop wildcard = "*"

  def test(source)
    pp max_length, enabled?, wildcard
  end
end

```

which will automatically be mapped to `MaxLength` configuration property in YAML configuration file:

```yaml
SuperRule:
  Enabled: false
  MaxLength: 100
  Wildcard: ".*" 
```

Closes #8