### PR TITLE
Extend installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Is still under construction, compatibility may be broken :construction:
 
 ## Installation
 
+### As a project dependency:
+
 Add this to your application's `shard.yml`:
 
 ```yaml
@@ -35,8 +37,21 @@ development_dependencies:
     github: veelenga/ameba
 ```
 
-That will compile and install `ameba` binary onto your system.
+Compile and install `ameba` binary onto your system while running `crystal deps`.
 
+### OS X
+
+```
+$ brew tap veelenga/tap
+$ brew install ameba
+```
+
+### From sources
+
+```
+$ git clone https://github.com/veelenga/ameba && cd ameba
+$ make install
+```
 Or just compile it from sources `make install`.
 
 ## Usage


### PR DESCRIPTION
Currently Ameba binary can be installed:

1. As a project dependency
2. Via `brew` on OS X
3. From sources

**I would appreciate if someone could help to maintain [AUR](https://aur.archlinux.org/) installation.**