### PR TITLE
Recognize individual files to process from CLI

### DIFF
--- a/src/ameba/cli/cmd.cr
+++ b/src/ameba/cli/cmd.cr
@@ -20,7 +20,7 @@ module Ameba::Cli
       parser.on("-v", "--version", "Print version") { print_version }
       parser.on("-h", "--help", "Show this help") { show_help parser }
       parser.on("-s", "--silent", "Disable output") { opts.silent = true }
-      parser.unknown_args { |f| files = f if f.any? }
+      parser.unknown_args { |f| opts.files = f if f.any? }
 
       parser.on("-c PATH", "--config PATH", "Specify configuration file") do |f|
         opts.config = f


### PR DESCRIPTION
Hello,

First and most important, thank you for your work on this project and making it public for others to use!

Recent refactor of code introduced a regression: provide individual files to CLI resulted in all *.cr files being processed instead, so given file was ignored.

This change restores the original behavior that allows more fine grained execution.

Once again, thank you for your work and hopefully you accept this contribution.
Cheers.
❤️ ❤️ ❤️ 