### PR TITLE
Flycheck formatter

### DIFF
--- a/spec/ameba/cli/cmd_spec.cr
+++ b/spec/ameba/cli/cmd_spec.cr
@@ -1,0 +1,69 @@
+require "../../spec_helper"
+require "../../../src/ameba/cli/cmd"
+
+module Ameba::Cli
+  describe "Cmd" do
+    it "has a list of available formatters" do
+      AVAILABLE_FORMATTERS.should_not be_nil
+    end
+
+    describe ".run" do
+      it "runs ameba" do
+        r = Cli.run %w(-f silent file.cr)
+        r.should be_nil
+      end
+    end
+
+    describe ".parse_args" do
+      %w(-s --silent).each do |f|
+        it "accepts #{f} flag" do
+          c = Cli.parse_args [f]
+          c.formatter.should eq :silent
+        end
+      end
+
+      %w(-c --config).each do |f|
+        it "accepts #{f} flag" do
+          c = Cli.parse_args [f, "config.yml"]
+          c.config.should eq "config.yml"
+        end
+      end
+
+      %w(-f --format).each do |f|
+        it "accepts #{f} flag" do
+          c = Cli.parse_args [f, "my-formatter"]
+          c.formatter.should eq "my-formatter"
+        end
+      end
+
+      it "accepts --only flag" do
+        c = Cli.parse_args ["--only", "RULE1,RULE2"]
+        c.only.should eq %w(RULE1 RULE2)
+      end
+
+      it "accepts --except flag" do
+        c = Cli.parse_args ["--except", "RULE1,RULE2"]
+        c.except.should eq %w(RULE1 RULE2)
+      end
+
+      it "accepts --gen-config flag" do
+        c = Cli.parse_args %w(--gen-config)
+        c.formatter.should eq :todo
+      end
+
+      it "accepts unknown args as files" do
+        c = Cli.parse_args %w(source1.cr source2.cr)
+        c.files.should eq %w(source1.cr source2.cr)
+      end
+
+      it "allows args to be blank" do
+        c = Cli.parse_args [] of String
+        c.formatter.should eq :progress
+        c.files.should be_nil
+        c.only.should be_nil
+        c.except.should be_nil
+        c.config.should eq Config::PATH
+      end
+    end
+  end
+end

--- a/spec/ameba/formatter/flycheck_formatter_spec.cr
+++ b/spec/ameba/formatter/flycheck_formatter_spec.cr
@@ -1,0 +1,44 @@
+require "../../spec_helper"
+
+private def flycheck
+  output = IO::Memory.new
+  Ameba::Formatter::FlycheckFormatter.new output
+end
+
+module Ameba::Formatter
+  describe FlycheckFormatter do
+    context "problems not found" do
+      it "reports nothing" do
+        subject = flycheck
+        subject.source_finished Source.new ""
+        subject.output.to_s.empty?.should be_true
+      end
+    end
+
+    context "when problems found" do
+      it "reports an error" do
+        s = Source.new "a = 1", "source.cr"
+        s.error DummyRule.new, s.location(1, 2), "message"
+        subject = flycheck
+        subject.source_finished s
+        subject.output.to_s.should eq "source.cr:1:2: E: message\n"
+      end
+
+      it "properly reports multi-line message" do
+        s = Source.new "a = 1", "source.cr"
+        s.error DummyRule.new, s.location(1, 2), "multi\nline"
+        subject = flycheck
+        subject.source_finished s
+        subject.output.to_s.should eq "source.cr:1:2: E: multi line\n"
+      end
+
+      it "reports nothing if location was not set" do
+        s = Source.new "a = 1", "source.cr"
+        s.error DummyRule.new, nil, "message"
+        subject = flycheck
+        subject.source_finished s
+        subject.output.to_s.should eq ""
+      end
+    end
+  end
+end

--- a/src/ameba/cli/cmd.cr
+++ b/src/ameba/cli/cmd.cr
@@ -14,7 +14,7 @@ module Ameba::Cli
 
   def run(args)
     opts = parse_args args
-    config = Ameba::Config.load opts.config
+    config = Config.load opts.config
     config.files = opts.files
 
     configure_formatter(config, opts)
@@ -27,7 +27,7 @@ module Ameba::Cli
   end
 
   private class Opts
-    property config = Ameba::Config::PATH
+    property config = Config::PATH
     property formatter : String | Symbol = :progress
     property files : Array(String)?
     property only : Array(String)?
@@ -65,7 +65,7 @@ module Ameba::Cli
 
       parser.on("--gen-config",
         "Generate a configuration file acting as a TODO list") do
-        opts.formatter = "todo"
+        opts.formatter = :todo
       end
     end
 
@@ -98,7 +98,7 @@ module Ameba::Cli
   end
 
   private def print_version
-    puts Ameba::VERSION
+    puts VERSION
     exit 0
   end
 

--- a/src/ameba/formatter/flycheck_formatter.cr
+++ b/src/ameba/formatter/flycheck_formatter.cr
@@ -1,0 +1,13 @@
+module Ameba::Formatter
+  class FlycheckFormatter < BaseFormatter
+    def source_finished(source : Source)
+      source.errors.each do |e|
+        if loc = e.location
+          output.printf "%s:%d:%d: %s: %s\n",
+            source.path, loc.line_number, loc.column_number, "E",
+            e.message.gsub("\n", " ")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This changes adds `FlycheckFormatter` which is basically will be used for editor integration #26.

Example:

```sh
$ ameba --format flycheck
src/ameba/config.cr:27:3: E: Favour method name 'picture?' over 'has_picture?'
src/ameba/runner.cr:81:5: E: Redundant `begin` block detected
```