### PR TITLE
Report invalid crystal syntax properly

### DIFF
--- a/spec/ameba/base_spec.cr
+++ b/spec/ameba/base_spec.cr
@@ -7,6 +7,19 @@ module Ameba::Rule
   end
 
   describe Base do
+    context ".rules" do
+      it "returns a list of all rules" do
+        rules = Rule.rules
+        rules.should_not be_nil
+        rules.should contain DummyRule
+        rules.should contain NoProperties
+      end
+
+      it "should not include syntax rule" do
+        Rule.rules.should_not contain Rule::Syntax
+      end
+    end
+
     context "properties" do
       subject = DummyRule.new
 

--- a/spec/ameba/formatter/todo_formatter_spec.cr
+++ b/spec/ameba/formatter/todo_formatter_spec.cr
@@ -50,6 +50,21 @@ module Ameba
       it "excludes source from this rule" do
         create_todo.should contain "Excluded:\n  - source.cr"
       end
+
+      context "when invalid syntax" do
+        it "does not exclude Syntax rule" do
+          file = IO::Memory.new
+          formatter = Formatter::TODOFormatter.new IO::Memory.new, file
+
+          s = Source.new "def invalid_syntax"
+          s.error Rule::Syntax.new, s.location(1, 2), "message"
+
+          formatter.finished [s]
+          content = file.to_s
+
+          content.should_not contain "Syntax"
+        end
+      end
     end
   end
 end

--- a/spec/ameba/rule/syntax_spec.cr
+++ b/spec/ameba/rule/syntax_spec.cr
@@ -9,7 +9,6 @@ module Ameba::Rule
         def hello
           puts "totally valid"
         rescue e: Exception
-          #
         end
       )
       subject.catch(s).should be_valid
@@ -20,7 +19,6 @@ module Ameba::Rule
         def hello
           puts "invalid"
         rescue Exception => e
-          #
         end
       )
       subject.catch(s).should_not be_valid

--- a/spec/ameba/rule/syntax_spec.cr
+++ b/spec/ameba/rule/syntax_spec.cr
@@ -1,0 +1,39 @@
+require "../../spec_helper"
+
+module Ameba::Rule
+  describe Syntax do
+    subject = Syntax.new
+
+    it "passes if there is no invalid syntax" do
+      s = Source.new %(
+        def hello
+          puts "totally valid"
+        rescue e: Exception
+          #
+        end
+      )
+      subject.catch(s).should be_valid
+    end
+
+    it "fails if there is an invalid syntax" do
+      s = Source.new %(
+        def hello
+          puts "invalid"
+        rescue Exception => e
+          #
+        end
+      )
+      subject.catch(s).should_not be_valid
+    end
+
+    it "reports rule, location and message" do
+      s = Source.new "def hello end", "source.cr"
+      subject.catch(s).should_not be_valid
+      error = s.errors.first
+
+      error.rule.should_not be_nil
+      error.location.to_s.should eq "source.cr:1:11"
+      error.message.should eq "unexpected token: end (expected ';' or newline)"
+    end
+  end
+end

--- a/spec/ameba/runner_spec.cr
+++ b/spec/ameba/runner_spec.cr
@@ -51,6 +51,30 @@ module Ameba
 
         Runner.new(rules, [source], formatter).run.success?.should be_true
       end
+
+      context "invalid syntax" do
+        it "reports a syntax error" do
+          rules = [Rule::Syntax.new] of Rule::Base
+          source = Source.new "def bad_syntax"
+
+          Runner.new(rules, [source], formatter).run
+          source.should_not be_valid
+          source.errors.first.rule.name.should eq "Syntax"
+        end
+
+        it "does not run other rules" do
+          rules = [Rule::Syntax.new, Rule::ConstantNames.new] of Rule::Base
+          source = Source.new %q(
+              MyBadConstant = 1
+
+              when my_bad_syntax
+          )
+
+          Runner.new(rules, [source], formatter).run
+          source.should_not be_valid
+          source.errors.size.should eq 1
+        end
+      end
     end
 
     describe "#success?" do

--- a/src/ameba/formatter/todo_formatter.cr
+++ b/src/ameba/formatter/todo_formatter.cr
@@ -31,6 +31,7 @@ module Ameba::Formatter
     private def rule_errors_map(errors)
       Hash(Rule::Base, Array(Source::Error)).new.tap do |h|
         errors.each do |error|
+          next if error.rule.is_a? Rule::Syntax
           h[error.rule] ||= Array(Source::Error).new
           h[error.rule] << error
         end

--- a/src/ameba/rule/base.cr
+++ b/src/ameba/rule/base.cr
@@ -82,13 +82,14 @@ module Ameba::Rule
     end
   end
 
-  # Returns a list of all available rules.
+  # Returns a list of all available rules
+  # (except a `Rule::Syntax` which is a special rule).
   #
   # ```
   # Ameba::Rule.rules # => [LineLength, ConstantNames, ....]
   # ```
   #
   def self.rules
-    Base.subclasses
+    Base.subclasses.reject! &.== Rule::Syntax
   end
 end

--- a/src/ameba/rule/syntax.cr
+++ b/src/ameba/rule/syntax.cr
@@ -1,0 +1,35 @@
+module Ameba::Rule
+  # A rule that reports invalid Crystal syntax.
+  #
+  # For example, this syntax is invalid:
+  #
+  # ```
+  # def hello
+  #   do_something
+  # rescue Exception => e
+  # end
+  # ```
+  #
+  # And should be properly written:
+  #
+  # ```
+  # def hello
+  #   do_something
+  # rescue e : Exception
+  # end
+  # ```
+  #
+  struct Syntax < Base
+    properties do
+      enabled = true
+      description = "Reports invalid Crystal syntax"
+    end
+
+    def test(source)
+      source.ast
+    rescue e : Crystal::SyntaxException
+      location = source.location(e.line_number, e.column_number)
+      source.error self, location, e.message.to_s
+    end
+  end
+end

--- a/src/ameba/rule/syntax.cr
+++ b/src/ameba/rule/syntax.cr
@@ -20,11 +20,6 @@ module Ameba::Rule
   # ```
   #
   struct Syntax < Base
-    properties do
-      enabled = true
-      description = "Reports invalid Crystal syntax"
-    end
-
     def test(source)
       source.ast
     rescue e : Crystal::SyntaxException

--- a/src/ameba/runner.cr
+++ b/src/ameba/runner.cr
@@ -20,6 +20,9 @@ module Ameba
     # A formatter to prepare report.
     @formatter : Formatter::BaseFormatter
 
+    # A syntax rule which always inspects a source first
+    @syntax_rule = Rule::Syntax.new
+
     # Instantiates a runner using a `config`.
     #
     # ```
@@ -57,9 +60,11 @@ module Ameba
       @sources.each do |source|
         @formatter.source_started source
 
-        @rules.each do |rule|
-          next if rule.excluded?(source)
-          rule.test(source)
+        if @syntax_rule.catch(source).valid?
+          @rules.each do |rule|
+            next if rule.excluded?(source)
+            rule.test(source)
+          end
         end
 
         @formatter.source_finished source


### PR DESCRIPTION
This change introduces a new rule `Rule::Syntax` which reports an error if `SyntaxException` is thrown. The rule can't be disabled and can't be added to the TODO file.

closes #11 

