### PR TITLE
Inline directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ It allows to configure rule properties, disable specific rules and exclude sourc
 
 Generate new file by running `ameba --gen-config`.
 
+### Inline disabling
+
+One or more rules can't be disabled using inline directives:
+
+```crystal
+# ameba:disable LargeNumbers
+time = Time.epoch(1483859302)
+
+time = Time.epoch(1483859302) # ameba:disable LargeNumbers
+```
+
 ## Writing a new Rule
 
 Adding a new rule is as simple as inheriting from `Ameba::Rule::Base` struct and implementing

--- a/spec/ameba/formatter/disabled_formatter_spec.cr
+++ b/spec/ameba/formatter/disabled_formatter_spec.cr
@@ -1,0 +1,41 @@
+require "../../spec_helper"
+
+module Ameba::Formatter
+  describe DisabledFormatter do
+    output = IO::Memory.new
+    subject = DisabledFormatter.new output
+
+    describe "#finished" do
+      it "writes a final message" do
+        subject.finished [Source.new ""]
+        output.to_s.should contain "Disabled rules using inline directives:"
+      end
+
+      it "writes disabled rules if any" do
+        Colorize.enabled = false
+
+        path = "source.cr"
+        s = Source.new("", path).tap do |s|
+          s.error(ErrorRule.new, 1, 2, "ErrorRule", :disabled)
+          s.error(NamedRule.new, 2, 2, "NamedRule", :disabled)
+        end
+        subject.finished [s]
+        log = output.to_s
+        log.should contain "#{path}:1 #{ErrorRule.name}"
+        log.should contain "#{path}:2 #{NamedRule.name}"
+      ensure
+        output.clear
+        Colorize.enabled = true
+      end
+
+      it "does not write not-disabled rules" do
+        s = Source.new("", "source.cr").tap do |s|
+          s.error(ErrorRule.new, 1, 2, "ErrorRule")
+          s.error(NamedRule.new, 2, 2, "NamedRule", :disabled)
+        end
+        subject.finished [s]
+        output.to_s.should_not contain ErrorRule.name
+      end
+    end
+  end
+end

--- a/spec/ameba/formatter/dot_formatter_spec.cr
+++ b/spec/ameba/formatter/dot_formatter_spec.cr
@@ -36,6 +36,27 @@ module Ameba::Formatter
         subject.finished [Source.new ""]
         output.to_s.should contain "Finished in"
       end
+
+      context "when errors found" do
+        it "writes each error" do
+          s = Source.new("").tap do |s|
+            s.error(DummyRule.new, 1, 1, "DummyRuleError")
+            s.error(NamedRule.new, 1, 2, "NamedRuleError")
+          end
+          subject.finished [s]
+          log = output.to_s
+          log.should contain "1 inspected, 2 failures."
+          log.should contain "DummyRuleError"
+          log.should contain "NamedRuleError"
+        end
+
+        it "does not write disabled errors" do
+          s = Source.new ""
+          s.error(DummyRule.new, 1, 1, "DummyRuleError", :disabled)
+          subject.finished [s]
+          output.to_s.should contain "1 inspected, 0 failures."
+        end
+      end
     end
   end
 end

--- a/spec/ameba/formatter/flycheck_formatter_spec.cr
+++ b/spec/ameba/formatter/flycheck_formatter_spec.cr
@@ -18,7 +18,7 @@ module Ameba::Formatter
     context "when problems found" do
       it "reports an error" do
         s = Source.new "a = 1", "source.cr"
-        s.error DummyRule.new, s.location(1, 2), "message"
+        s.error DummyRule.new, 1, 2, "message"
         subject = flycheck
         subject.source_finished s
         subject.output.to_s.should eq "source.cr:1:2: E: message\n"
@@ -26,7 +26,7 @@ module Ameba::Formatter
 
       it "properly reports multi-line message" do
         s = Source.new "a = 1", "source.cr"
-        s.error DummyRule.new, s.location(1, 2), "multi\nline"
+        s.error DummyRule.new, 1, 2, "multi\nline"
         subject = flycheck
         subject.source_finished s
         subject.output.to_s.should eq "source.cr:1:2: E: multi line\n"

--- a/spec/ameba/formatter/todo_formatter_spec.cr
+++ b/spec/ameba/formatter/todo_formatter_spec.cr
@@ -6,7 +6,7 @@ module Ameba
     formatter = Formatter::TODOFormatter.new IO::Memory.new, file
 
     s = Source.new "a = 1", "source.cr"
-    s.error DummyRule.new, s.location(1, 2), "message"
+    s.error DummyRule.new, 1, 2, "message"
 
     formatter.finished [s]
     file.to_s
@@ -57,7 +57,7 @@ module Ameba
           formatter = Formatter::TODOFormatter.new IO::Memory.new, file
 
           s = Source.new "def invalid_syntax"
-          s.error Rule::Syntax.new, s.location(1, 2), "message"
+          s.error Rule::Syntax.new, 1, 2, "message"
 
           formatter.finished [s]
           content = file.to_s

--- a/spec/ameba/inline_comments_spec.cr
+++ b/spec/ameba/inline_comments_spec.cr
@@ -1,0 +1,87 @@
+require "../spec_helper"
+
+module Ameba
+  describe InlineComments do
+    it "disables a rule with a comment directive" do
+      s = Source.new %Q(
+        # ameba:disable #{NamedRule.name}
+        Time.epoch(1483859302)
+      )
+      s.error(NamedRule.new, 3, 12, "Error!")
+      s.should be_valid
+    end
+
+    it "disables a rule with a line that ends with a comment directive" do
+      s = Source.new %Q(
+        Time.epoch(1483859302) # ameba:disable #{NamedRule.name}
+      )
+      s.error(NamedRule.new, 2, 12, "Error!")
+      s.should be_valid
+    end
+
+    it "does not disable a rule of a different name" do
+      s = Source.new %Q(
+        # ameba:disable WrongName
+        Time.epoch(1483859302)
+      )
+      s.error(NamedRule.new, 3, 12, "Error!")
+      s.should_not be_valid
+    end
+
+    it "disables a rule if multiple rule names provided" do
+      s = Source.new %Q(
+        # ameba:disable SomeRule LargeNumbers #{NamedRule.name} SomeOtherRule
+        Time.epoch(1483859302)
+      )
+      s.error(NamedRule.new, 3, 12, "")
+      s.should be_valid
+    end
+
+    it "disables a rule if multiple rule names are separated by comma" do
+      s = Source.new %Q(
+        # ameba:disable SomeRule, LargeNumbers, #{NamedRule.name}, SomeOtherRule
+        Time.epoch(1483859302)
+      )
+      s.error(NamedRule.new, 3, 12, "")
+      s.should be_valid
+    end
+
+    it "does not disable if multiple rule names used without required one" do
+      s = Source.new %(
+        # ameba:disable SomeRule, SomeOtherRule LargeNumbers
+        Time.epoch(1483859302)
+      )
+      s.error(NamedRule.new, 3, 12, "")
+      s.should_not be_valid
+    end
+
+    it "does not disable if comment directive has wrong place" do
+      s = Source.new %Q(
+        # ameba:disable #{NamedRule.name}
+        #
+        Time.epoch(1483859302)
+      )
+      s.error(NamedRule.new, 4, 12, "")
+      s.should_not be_valid
+    end
+
+    it "does not disable if comment directive added to the wrong line" do
+      s = Source.new %Q(
+        if use_epoch? # ameba:disable #{NamedRule.name}
+          Time.epoch(1483859302)
+        end
+      )
+      s.error(NamedRule.new, 3, 12, "")
+      s.should_not be_valid
+    end
+
+    it "does not disable if that is not a comment directive" do
+      s = Source.new %Q(
+        "ameba:disable #{NamedRule.name}"
+        Time.epoch(1483859302)
+      )
+      s.error(NamedRule.new, 3, 12, "")
+      s.should_not be_valid
+    end
+  end
+end

--- a/spec/ameba/source_spec.cr
+++ b/spec/ameba/source_spec.cr
@@ -14,7 +14,7 @@ module Ameba
     describe "#error" do
       it "adds and error" do
         s = Source.new "", "source.cr"
-        s.error(DummyRule.new, s.location(23, 2), "Error!")
+        s.error(DummyRule.new, 23, 2, "Error!")
         s.should_not be_valid
 
         error = s.errors.first

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -11,6 +11,19 @@ module Ameba
     end
   end
 
+  struct NamedRule < Rule::Base
+    properties do
+      description : String = "A rule with a custom name."
+    end
+
+    def test(source)
+    end
+
+    def self.name
+      "BreakingRule"
+    end
+  end
+
   struct ErrorRule < Rule::Base
     def test(source)
       source.error self, 1, 1, "This rule always adds an error"

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -13,8 +13,7 @@ module Ameba
 
   struct ErrorRule < Rule::Base
     def test(source)
-      source.error self, source.location(1, 1),
-        "This rule always adds an error"
+      source.error self, 1, 1, "This rule always adds an error"
     end
   end
 

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -17,6 +17,7 @@ class Ameba::Config
     todo:     Formatter::TODOFormatter,
     flycheck: Formatter::FlycheckFormatter,
     silent:   Formatter::BaseFormatter,
+    disabled: Formatter::DisabledFormatter,
   }
 
   PATH = ".ameba.yml"

--- a/src/ameba/formatter/disabled_formatter.cr
+++ b/src/ameba/formatter/disabled_formatter.cr
@@ -1,0 +1,17 @@
+module Ameba::Formatter
+  # A formatter that shows all disabled line using inline directives.
+  class DisabledFormatter < BaseFormatter
+    def finished(sources)
+      output << "Disabled rules using inline directives: \n\n"
+
+      sources.each do |source|
+        source.errors.select(&.disabled?).each do |e|
+          if loc = e.location
+            output << "#{source.path}:#{loc.line_number}".colorize(:cyan)
+            output << " #{e.rule.name}\n"
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/ameba/formatter/dot_formatter.cr
+++ b/src/ameba/formatter/dot_formatter.cr
@@ -25,6 +25,7 @@ module Ameba::Formatter
 
       failed_sources.each do |source|
         source.errors.each do |error|
+          next if error.disabled?
           output << "#{error.location}\n".colorize(:cyan)
           output << "#{error.rule.name}: #{error.message}\n\n".colorize(:red)
         end

--- a/src/ameba/formatter/flycheck_formatter.cr
+++ b/src/ameba/formatter/flycheck_formatter.cr
@@ -2,6 +2,7 @@ module Ameba::Formatter
   class FlycheckFormatter < BaseFormatter
     def source_finished(source : Source)
       source.errors.each do |e|
+        next if e.disabled?
         if loc = e.location
           output.printf "%s:%d:%d: %s: %s\n",
             source.path, loc.line_number, loc.column_number, "E",

--- a/src/ameba/formatter/todo_formatter.cr
+++ b/src/ameba/formatter/todo_formatter.cr
@@ -31,7 +31,7 @@ module Ameba::Formatter
     private def rule_errors_map(errors)
       Hash(Rule::Base, Array(Source::Error)).new.tap do |h|
         errors.each do |error|
-          next if error.rule.is_a? Rule::Syntax
+          next if error.disabled? || error.rule.is_a? Rule::Syntax
           h[error.rule] ||= Array(Source::Error).new
           h[error.rule] << error
         end

--- a/src/ameba/inline_comments.cr
+++ b/src/ameba/inline_comments.cr
@@ -10,7 +10,7 @@ module Ameba
     #   1. The line of the location ends with a comment directive.
     #   2. The line above the location is a comment directive.
     #
-    # For example, here is two examples of disabled location:
+    # For example, here are two examples of disabled location:
     #
     # ```
     # # ameba:disable LargeNumbers

--- a/src/ameba/inline_comments.cr
+++ b/src/ameba/inline_comments.cr
@@ -1,0 +1,63 @@
+module Ameba
+  # A module that represents inline comments parsing and processing logic.
+  module InlineComments
+    COMMENT_DIRECTIVE_REGEX = Regex.new "# ameba : (\\w+) ([\\w, ]+)".gsub(" ", "\\s*")
+
+    # Returns true if current location is disabled for a particular rule,
+    # false otherwise.
+    #
+    # Location is disabled in two cases:
+    #   1. The line of the location ends with a comment directive.
+    #   2. The line above the location is a comment directive.
+    #
+    # For example, here is two examples of disabled location:
+    #
+    # ```
+    # # ameba:disable LargeNumbers
+    # Time.epoch(1483859302)
+    #
+    # Time.epoch(1483859302) # ameba:disable LargeNumbers
+    # ```
+    #
+    # But here are examples which are not considered as disabled location:
+    #
+    # ```
+    # # ameba:disable LargeNumbers
+    # #
+    # Time.epoch(1483859302)
+    #
+    # if use_epoch? # ameba:disable LargeNumbers
+    #   Time.epoch(1483859302)
+    # end
+    # ```
+    #
+    def location_disabled?(location, rule)
+      return false unless line_number = location.try &.line_number.try &.- 1
+      return false unless line = lines[line_number]?
+
+      line_disabled?(line, rule) ||
+        (line_number > 0 &&
+          (prev_line = lines[line_number - 1]) &&
+          comment?(prev_line) &&
+          line_disabled?(prev_line, rule))
+    end
+
+    private def comment?(line)
+      line.lstrip.starts_with? '#'
+    end
+
+    private def line_disabled?(line, rule)
+      return false unless inline_comment = parse_inline_comment(line)
+      inline_comment[:action] == "disable" && inline_comment[:rules].includes?(rule)
+    end
+
+    private def parse_inline_comment(line)
+      if comment = COMMENT_DIRECTIVE_REGEX.match(line)
+        {
+          action: comment[1],
+          rules:  comment[2].split(/[\s,]/, remove_empty: true),
+        }
+      end
+    end
+  end
+end

--- a/src/ameba/rule/line_length.cr
+++ b/src/ameba/rule/line_length.cr
@@ -20,8 +20,7 @@ module Ameba::Rule
       source.lines.each_with_index do |line, index|
         next unless line.size > max_length
 
-        source.error self, source.location(index + 1, line.size),
-          "Line too long"
+        source.error self, index + 1, line.size, "Line too long"
       end
     end
   end

--- a/src/ameba/rule/syntax.cr
+++ b/src/ameba/rule/syntax.cr
@@ -23,8 +23,7 @@ module Ameba::Rule
     def test(source)
       source.ast
     rescue e : Crystal::SyntaxException
-      location = source.location(e.line_number, e.column_number)
-      source.error self, location, e.message.to_s
+      source.error self, e.line_number, e.column_number, e.message.to_s
     end
   end
 end

--- a/src/ameba/rule/trailing_blank_lines.cr
+++ b/src/ameba/rule/trailing_blank_lines.cr
@@ -15,7 +15,7 @@ module Ameba::Rule
 
     def test(source)
       if source.lines.size > 1 && source.lines[-2, 2].join.strip.empty?
-        source.error self, source.location(source.lines.size, 1),
+        source.error self, source.lines.size, 1,
           "Blank lines detected at the end of the file"
       end
     end

--- a/src/ameba/rule/trailing_whitespace.cr
+++ b/src/ameba/rule/trailing_whitespace.cr
@@ -16,8 +16,7 @@ module Ameba::Rule
     def test(source)
       source.lines.each_with_index do |line, index|
         next unless line =~ /\s$/
-        source.error self, source.location(index + 1, line.size),
-          "Trailing whitespace detected"
+        source.error self, index + 1, line.size, "Trailing whitespace detected"
       end
     end
   end

--- a/src/ameba/source.cr
+++ b/src/ameba/source.cr
@@ -36,7 +36,7 @@ module Ameba
     def initialize(@code : String, @path = "")
     end
 
-    # Add new error to the list of errors.
+    # Adds new error to the list of errors.
     #
     # ```
     # source.error rule, location, "Line too long"
@@ -44,6 +44,17 @@ module Ameba
     #
     def error(rule : Rule::Base, location, message : String)
       errors << Error.new rule, location, message
+    end
+
+    # Adds new error to the list of errors using line and column number.
+    #
+    # ```
+    # source.error rule, line_number, column_number, "Bad code"
+    # ```
+    #
+    def error(rule : Rule::Base, l : Int32, c : Int32, message : String)
+      location = Crystal::Location.new path, l, c
+      error rule, location, message
     end
 
     # Indicates whether source is valid or not.
@@ -87,18 +98,6 @@ module Ameba
         Crystal::Parser.new(code)
                        .tap { |parser| parser.filename = @path }
                        .parse
-    end
-
-    # Returns a new instance of the `Crystal::Location` in current
-    # source based on the line number `l` and column number `c`.
-    #
-    # ```
-    # s = Ameba::Source.new code, path
-    # s.location(3, 76)
-    # ```
-    #
-    def location(l, c)
-      Crystal::Location.new path, l, c
     end
 
     def fullpath

--- a/src/ameba/source.cr
+++ b/src/ameba/source.cr
@@ -7,7 +7,7 @@ module Ameba
     # Represents an error caught by Ameba.
     #
     # Each error has the rule that created this error,
-    # location of the issue and a message.
+    # location of the issue, message and status.
     record Error,
       rule : Rule::Base,
       location : Crystal::Location?,
@@ -43,7 +43,7 @@ module Ameba
     def initialize(@code : String, @path = "")
     end
 
-    # Adds new error to the list of errors.
+    # Adds a new error to the list of errors.
     #
     # ```
     # source.error rule, location, "Line too long"
@@ -54,7 +54,7 @@ module Ameba
       errors << Error.new rule, location, message, status
     end
 
-    # Adds new error to the list of errors using line and column number.
+    # Adds a new error to the list of errors using line and column number.
     #
     # ```
     # source.error rule, line_number, column_number, "Bad code"


### PR DESCRIPTION
This PR adds support for inline directives via comments.

The end user can write (both ways are equivalent) :

```
# ameba:disable LargeNumbers
time = Time.epoch(1483859302)

time = Time.epoch(1483859302) # ameba:disable LargeNumbers
```
that directive disables inspection of that particular line by the rule named `LargeNumbers`.

It is also possible to disable multiple rules:

```
# ameba:disable VariableNames, LargeNumbers
myTime = Time.epoch(1483859302)
```

/cc @taylorfinnell

closes #28
