### PR TITLE
Unneeded disable directive

### DIFF
--- a/spec/ameba/base_spec.cr
+++ b/spec/ameba/base_spec.cr
@@ -14,10 +14,6 @@ module Ameba::Rule
         rules.should contain DummyRule
         rules.should contain NoProperties
       end
-
-      it "should not include syntax rule" do
-        Rule.rules.should_not contain Rule::Syntax
-      end
     end
 
     context "properties" do

--- a/spec/ameba/config_spec.cr
+++ b/spec/ameba/config_spec.cr
@@ -66,14 +66,14 @@ module Ameba
       config = Config.load config_sample
 
       it "updates enabled property" do
-        name = DummyRule.class_name
+        name = DummyRule.rule_name
         config.update_rule name, enabled: false
         rule = config.rules.find(&.name.== name).not_nil!
         rule.enabled.should be_false
       end
 
       it "updates excluded property" do
-        name = DummyRule.class_name
+        name = DummyRule.rule_name
         excluded = %w(spec/source.cr)
         config.update_rule name, excluded: excluded
         rule = config.rules.find(&.name.== name).not_nil!

--- a/spec/ameba/formatter/todo_formatter_spec.cr
+++ b/spec/ameba/formatter/todo_formatter_spec.cr
@@ -44,7 +44,7 @@ module Ameba
       end
 
       it "creates a todo with run details" do
-        create_todo.should contain "Run `ameba --only #{DummyRule.class_name}`"
+        create_todo.should contain "Run `ameba --only #{DummyRule.rule_name}`"
       end
 
       it "excludes source from this rule" do

--- a/spec/ameba/inline_comments_spec.cr
+++ b/spec/ameba/inline_comments_spec.cr
@@ -83,5 +83,22 @@ module Ameba
       s.error(NamedRule.new, 3, 12, "")
       s.should_not be_valid
     end
+
+    it "does not disable if that is a commented out directive" do
+      s = Source.new %Q(
+        # # ameba:disable #{NamedRule.name}
+        Time.epoch(1483859302)
+      )
+      s.error(NamedRule.new, 3, 12, "")
+      s.should_not be_valid
+    end
+
+    it "does not disable if that is an inline commented out directive" do
+      s = Source.new %Q(
+        a = 1 # Disable it: # ameba:disable #{NamedRule.name}
+      )
+      s.error(NamedRule.new, 2, 12, "")
+      s.should_not be_valid
+    end
   end
 end

--- a/spec/ameba/rule/unneded_disable_directive_spec.cr
+++ b/spec/ameba/rule/unneded_disable_directive_spec.cr
@@ -67,7 +67,7 @@ module Ameba::Rule
 
     it "fails if there is disabled UnneededDisableDirective" do
       s = Source.new %Q(
-        # ameba:disable #{UnneededDisableDirective.class_name}
+        # ameba:disable #{UnneededDisableDirective.rule_name}
         a = 1
       ), "source.cr"
       s.error UnneededDisableDirective.new, 3, 1, "Alarm!", :disabled

--- a/spec/ameba/rule/unneded_disable_directive_spec.cr
+++ b/spec/ameba/rule/unneded_disable_directive_spec.cr
@@ -1,0 +1,80 @@
+require "../../spec_helper"
+
+module Ameba::Rule
+  describe UnneededDisableDirective do
+    subject = UnneededDisableDirective.new
+
+    it "passes if there are no comments" do
+      s = Source.new %(
+        a = 1
+      )
+      subject.catch(s).should be_valid
+    end
+
+    it "passes if there is disable directive" do
+      s = Source.new %(
+        a = 1 # my super var
+      )
+      subject.catch(s).should be_valid
+    end
+
+    it "passes if there is disable directive and it is needed" do
+      s = Source.new %Q(
+        a = 1 # ameba:disable #{NamedRule.name}
+      )
+      s.error NamedRule.new, 2, 1, "Alarm!", :disabled
+      subject.catch(s).should be_valid
+    end
+
+    it "ignores commented out disable directive" do
+      s = Source.new %Q(
+        # # ameba:disable #{NamedRule.name}
+        a = 1
+      )
+      s.error NamedRule.new, 3, 1, "Alarm!", :disabled
+      subject.catch(s).should be_valid
+    end
+
+    it "failes if there is unneeded directive" do
+      s = Source.new %Q(
+        # ameba:disable #{NamedRule.name}
+        a = 1
+      )
+      subject.catch(s).should_not be_valid
+      s.errors.first.message.should eq(
+        "Unnecessary disabling of #{NamedRule.name}"
+      )
+    end
+
+    it "fails if there is inline unneeded directive" do
+      s = Source.new %Q(a = 1 # ameba:disable #{NamedRule.name})
+      subject.catch(s).should_not be_valid
+      s.errors.first.message.should eq(
+        "Unnecessary disabling of #{NamedRule.name}"
+      )
+    end
+
+    it "detects mixed inline directives" do
+      s = Source.new %Q(
+        # ameba:disable Rule1, Rule2
+        a = 1 # ameba:disable Rule3
+      ), "source.cr"
+      subject.catch(s).should_not be_valid
+      s.errors.size.should eq 2
+      s.errors.first.message.should contain "Rule1, Rule2"
+      s.errors.last.message.should contain "Rule3"
+    end
+
+    it "reports error, location and message" do
+      s = Source.new %Q(
+        # ameba:disable Rule1, Rule2
+        a = 1
+      ), "source.cr"
+      subject.catch(s).should_not be_valid
+      error = s.errors.first
+      error.rule.should_not be_nil
+      error.location.to_s.should eq "source.cr:2:9"
+      error.message.should eq "Unnecessary disabling of Rule1, Rule2"
+    end
+  end
+end

--- a/spec/ameba/rule/unneded_disable_directive_spec.cr
+++ b/spec/ameba/rule/unneded_disable_directive_spec.cr
@@ -65,6 +65,15 @@ module Ameba::Rule
       s.errors.last.message.should contain "Rule3"
     end
 
+    it "fails if there is disabled UnneededDisableDirective" do
+      s = Source.new %Q(
+        # ameba:disable #{UnneededDisableDirective.class_name}
+        a = 1
+      ), "source.cr"
+      s.error UnneededDisableDirective.new, 3, 1, "Alarm!", :disabled
+      subject.catch(s).should_not be_valid
+    end
+
     it "reports error, location and message" do
       s = Source.new %Q(
         # ameba:disable Rule1, Rule2

--- a/spec/ameba/runner_spec.cr
+++ b/spec/ameba/runner_spec.cr
@@ -6,7 +6,7 @@ module Ameba
     config.formatter = formatter
     config.files = files
 
-    config.update_rule ErrorRule.class_name, enabled: false
+    config.update_rule ErrorRule.rule_name, enabled: false
 
     Runner.new(config)
   end
@@ -59,7 +59,7 @@ module Ameba
 
           Runner.new(rules, [source], formatter).run
           source.should_not be_valid
-          source.errors.first.rule.name.should eq "Syntax"
+          source.errors.first.rule.name.should eq Rule::Syntax.rule_name
         end
 
         it "does not run other rules" do
@@ -73,6 +73,19 @@ module Ameba
           Runner.new(rules, [source], formatter).run
           source.should_not be_valid
           source.errors.size.should eq 1
+        end
+      end
+
+      context "unneeded disables" do
+        it "reports an error if such disable exists" do
+          rules = [Rule::UnneededDisableDirective.new] of Rule::Base
+          source = Source.new %(
+            a = 1 # ameba:disable LineLength
+          )
+
+          Runner.new(rules, [source], formatter).run
+          source.should_not be_valid
+          source.errors.first.rule.name.should eq Rule::UnneededDisableDirective.rule_name
         end
       end
     end

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -186,7 +186,7 @@ class Ameba::Config
 
         def self.new(config = nil)
           if (raw = config.try &.raw).is_a? Hash
-            yaml = raw[class_name]?.try &.to_yaml
+            yaml = raw[rule_name]?.try &.to_yaml
           end
           from_yaml yaml || "{}"
         end

--- a/src/ameba/inline_comments.cr
+++ b/src/ameba/inline_comments.cr
@@ -32,6 +32,7 @@ module Ameba
     # ```
     #
     def location_disabled?(location, rule)
+      return false if Rule::SPECIAL.includes?(rule)
       return false unless line_number = location.try &.line_number.try &.- 1
       return false unless line = lines[line_number]?
 

--- a/src/ameba/rule/base.cr
+++ b/src/ameba/rule/base.cr
@@ -1,4 +1,9 @@
 module Ameba::Rule
+  SPECIAL = [
+    Syntax.class_name,
+    UnneededDisableDirective.class_name,
+  ]
+
   # Represents a base of all rules. In other words, all rules
   # inherits from this struct:
   #

--- a/src/ameba/rule/base.cr
+++ b/src/ameba/rule/base.cr
@@ -1,7 +1,9 @@
 module Ameba::Rule
+  # List of names of the special rules, which
+  # behave differently than usual rules.
   SPECIAL = [
-    Syntax.class_name,
-    UnneededDisableDirective.class_name,
+    Syntax.rule_name,
+    UnneededDisableDirective.rule_name,
   ]
 
   # Represents a base of all rules. In other words, all rules
@@ -60,7 +62,7 @@ module Ameba::Rule
     # ```
     #
     def name
-      {{@type}}.class_name
+      {{@type}}.rule_name
     end
 
     # Checks whether the source is excluded from this rule.
@@ -78,7 +80,18 @@ module Ameba::Rule
       end
     end
 
-    protected def self.class_name
+    # Returns true if this rule is special and behaves differently than
+    # usual rules.
+    #
+    # ```
+    # my_rule.special? # => true or false
+    # ```
+    #
+    def special?
+      SPECIAL.includes? name
+    end
+
+    protected def self.rule_name
       name.gsub("Ameba::Rule::", "")
     end
 
@@ -95,6 +108,6 @@ module Ameba::Rule
   # ```
   #
   def self.rules
-    Base.subclasses.reject! &.== Rule::Syntax
+    Base.subclasses
   end
 end

--- a/src/ameba/rule/unneeded_disable_directive.cr
+++ b/src/ameba/rule/unneeded_disable_directive.cr
@@ -1,0 +1,50 @@
+module Ameba::Rule
+  # A rule that reports unneeded disable directives.
+  # For example, this is considered invalid:
+  #
+  # ```
+  # # ameba:disable PredicateName
+  # def comment?
+  #   do_something
+  # end
+  # ```
+  #
+  # as the predicate name is correct and comment directive does not
+  # have any effect, the snippet should be written as the following:
+  #
+  # ```
+  # def comment?
+  #   do_something
+  # end
+  # ```
+  #
+  struct UnneededDisableDirective < Base
+    properties do
+      description = "Reports unneeded disable directives in comments"
+    end
+
+    def test(source)
+      Tokenizer.new(source).run do |token|
+        next unless token.type == :COMMENT
+        next unless directive = source.parse_inline_directive(token.value.to_s)
+        next unless names = unneeded_disables(source, directive, token.location)
+        next unless names.any?
+
+        source.error self, token.location,
+          "Unnecessary disabling of #{names.join(", ")}"
+      end
+    end
+
+    private def unneeded_disables(source, directive, location)
+      return unless directive[:action] == "disable"
+
+      directive[:rules].reject do |rule_name|
+        any = source.errors.any? do |error|
+          error.rule.name == rule_name &&
+            error.disabled? &&
+            error.location.try(&.line_number) == location.line_number
+        end
+      end
+    end
+  end
+end

--- a/src/ameba/rule/unneeded_disable_directive.cr
+++ b/src/ameba/rule/unneeded_disable_directive.cr
@@ -9,7 +9,7 @@ module Ameba::Rule
   # end
   # ```
   #
-  # as the predicate name is correct and comment directive does not
+  # as the predicate name is correct and the comment directive does not
   # have any effect, the snippet should be written as the following:
   #
   # ```
@@ -39,11 +39,11 @@ module Ameba::Rule
       return unless directive[:action] == "disable"
 
       directive[:rules].reject do |rule_name|
-        any = source.errors.any? do |error|
+        source.errors.any? do |error|
           error.rule.name == rule_name &&
             error.disabled? &&
             error.location.try(&.line_number) == location.line_number
-        end
+        end && rule_name != self.name
       end
     end
   end

--- a/src/ameba/tokenizer.cr
+++ b/src/ameba/tokenizer.cr
@@ -27,6 +27,16 @@ module Ameba
       @lexer.filename = source.path
     end
 
+    # Instantiates Tokenizer using a `lexer`.
+    #
+    # ```
+    # lexer = Crystal::Lexer.new(code)
+    # Ameba::Tokenizer.new(lexer)
+    # ```
+    #
+    def initialize(@lexer : Crystal::Lexer)
+    end
+
     # Runs the tokenizer and yields each token as a block argument.
     #
     # ```


### PR DESCRIPTION
This PR suggests adding a new rule that checks for unneeded disable directives implemented in #33.

  For example, this is considered invalid:
  
  ```
  # ameba:disable PredicateName
  def comment?
    do_something
  end
  ```
  
  as the predicate name is correct and the comment directive does not have any effect, the snippet should be written as the following:
  
  ```
  def comment?
    do_something
  end
  ```
