### PR TITLE
Build with --release flag instead of --no-debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PREFIX ?= /usr/local
 SHARD_BIN ?= ../../bin
 
 build:
-	$(SHARDS_BIN) build --no-debug $(CRFLAGS)
+	$(SHARDS_BIN) build --release $(CRFLAGS)
 clean:
 	rm -f ./bin/ameba
 install: build


### PR DESCRIPTION
As per https://github.com/crystal-lang/shards/pull/126#issuecomment-380790538