### PR TITLE
Crystal source formatting rule

### DIFF
--- a/spec/ameba/rule/formatting_spec.cr
+++ b/spec/ameba/rule/formatting_spec.cr
@@ -1,0 +1,58 @@
+require "../../spec_helper"
+
+module Ameba
+  describe Rule::Formatting do
+    subject = Rule::Formatting.new
+
+    it "passes if source is formatted" do
+      s = Source.new "def method(a, b)\n  a + b\nend\n"
+      subject.catch(s).should be_valid
+    end
+
+    it "reports if source is not formatted" do
+      s = Source.new %(
+        def method(a,b)
+        end
+      )
+      subject.catch(s).should_not be_valid
+    end
+
+    it "reports if source can not be formatted" do
+      s = Source.new %(
+        def method(a, b)
+          a + b
+      )
+      subject.catch(s).should_not be_valid
+    end
+
+    context "when fail_if_error set to false" do
+      it "does not report if source can not be formatted" do
+        rule = Rule::Formatting.new
+        rule.fail_if_error = false
+        s = Source.new %(
+          def method(a, b)
+            a + b
+        )
+        rule.catch(s).should be_valid
+      end
+    end
+
+    it "reports rule, location and message" do
+      s = Source.new %(
+        class A
+          ONE = 1
+          TWO = 2
+          THREE = 3
+        end
+      ), "source.cr"
+      subject.catch(s).should_not be_valid
+
+      error = s.errors.first
+      error.rule.should_not be_nil
+      error.location.to_s.should eq "source.cr:1:1"
+      error.message.should eq(
+        "Use built-in formatter to format this source"
+      )
+    end
+  end
+end

--- a/src/ameba/rule/formatting.cr
+++ b/src/ameba/rule/formatting.cr
@@ -1,0 +1,35 @@
+require "compiler/crystal/formatter"
+
+module Ameba::Rule
+  # A rule that verifies syntax formatting according to
+  # Crystal's build-in formatter.
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Formatting:
+  #   Enabled: true
+  #   FailIfError: true
+  # ```
+  #
+  struct Formatting < Base
+    properties do
+      description = "Reports not formatted sources"
+      fail_if_error = true
+    end
+
+    MSG     = "Use built-in formatter to format this source"
+    MSG_ERR = "Source file can't be formatted: '%s'"
+
+    def test(source)
+      result = Crystal.format(source.code, filename: source.path)
+      return if result == source.code
+
+      source.error self, 1, 1, MSG
+    rescue e
+      if fail_if_error
+        source.error self, 1, 1, MSG_ERR % e.message
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #40 

Reports if `crystal tool format --check` fails.

https://github.com/crystal-lang/crystal/blob/master/src/compiler/crystal/command/format.cr#L83-L84