### PR TITLE
Support upcoming Crystal 0.25.0

### DIFF
--- a/spec/ameba/formatter/json_formatter_spec.cr
+++ b/spec/ameba/formatter/json_formatter_spec.cr
@@ -26,7 +26,7 @@ module Ameba
     context "sources" do
       it "shows path to the source" do
         result = get_result [Source.new "", "source.cr"]
-        result["sources"].first["path"].should eq "source.cr"
+        result["sources"][0]["path"].should eq "source.cr"
       end
 
       it "shows rule name" do
@@ -34,7 +34,7 @@ module Ameba
         s.error DummyRule.new, 1, 2, "message1"
 
         result = get_result [s]
-        result["sources"].first["errors"].first["rule_name"].should eq DummyRule.name
+        result["sources"][0]["errors"][0]["rule_name"].should eq DummyRule.name
       end
 
       it "shows a message" do
@@ -42,7 +42,7 @@ module Ameba
         s.error DummyRule.new, 1, 2, "message"
 
         result = get_result [s]
-        result["sources"].first["errors"].first["message"].should eq "message"
+        result["sources"][0]["errors"][0]["message"].should eq "message"
       end
 
       it "shows error location" do
@@ -50,7 +50,7 @@ module Ameba
         s.error DummyRule.new, 1, 2, "message"
 
         result = get_result [s]
-        location = result["sources"].first["errors"].first["location"]
+        location = result["sources"][0]["errors"][0]["location"]
         location["line"].should eq 1
         location["column"].should eq 2
       end

--- a/spec/ameba/runner_spec.cr
+++ b/spec/ameba/runner_spec.cr
@@ -100,7 +100,7 @@ module Ameba
       end
 
       it "returns false if there are invalid sources" do
-        rules = Rule.rules.map &.new
+        rules = Rule.rules.map &.new.as(Rule::Base)
         s = Source.new %q(
           WrongConstant = 5
         )

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -30,7 +30,7 @@ class Ameba::Config
   #
   # `Config.load` uses this constructor to instantiate new config by YAML file.
   protected def initialize(@config : YAML::Any)
-    @rules = Rule.rules.map &.new(config)
+    @rules = Rule.rules.map &.new(config).as(Rule::Base)
 
     if @config.as_h? && (name = @config["Formatter"]?.try &.["Name"]?)
       self.formatter = name.to_s


### PR DESCRIPTION
The changes are compatible with crystal 0.24.2

There are changes in the JSON::Any API and due to some internal changes the Rule::Base module either need to be transformed to a class, or the cast introduced in the PR is needed.