### PR TITLE
Feature/dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.*
+Dockerfile
+Makefile
+bench/
+bin/
+spec/
+
+*.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . /ameba/
 RUN shards build --release
 
 FROM alpine:3.8
-RUN apk add --update crystal openssl yaml pcre gc libevent libgcc
+RUN apk add --update openssl yaml pcre gc libevent libgcc
 RUN mkdir /src
 WORKDIR /src
 COPY --from=builder /ameba/bin/ameba /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.8 as builder
+RUN apk add --update crystal shards openssl-dev yaml-dev libxml2-dev musl-dev
+RUN mkdir /ameba
+WORKDIR /ameba
+COPY . /ameba/
+RUN shards build --release
+
+FROM alpine:3.8
+RUN apk add --update crystal openssl yaml pcre gc libevent libgcc
+RUN mkdir /src
+WORKDIR /src
+COPY --from=builder /ameba/bin/ameba /usr/bin/
+ENTRYPOINT [ "/usr/bin/ameba" ]


### PR DESCRIPTION
This adds a `Dockerfile` (and a `.dockerignore`) that can be used to build a ready-to-use ameba Docker image, suitable for Gitlab CI, for example.

To build manually, one can do:

```
$ docker build -t ameba/ameba .
```

To use the resulting image on a local source folder, one has to "volume mount" the current (or target) directory into `/src`:

```
$ docker run -v $(pwd):/src ameba/ameba
```

To use it as part of a Gitlab CI build, for example, it's enough to go:

```
ameba:
  stage: test
  image: ameba/ameba
  script:
    - /usr/bin/ameba
```

The Docker image is based off `alpine:3.8` for the smallest footprint, and weighs in at only around 15.4 MB.