### PR TITLE
Extend UnreachableCode rule: handle control flow

### DIFF
--- a/spec/ameba/ast/flow_expression_spec.cr
+++ b/spec/ameba/ast/flow_expression_spec.cr
@@ -5,42 +5,37 @@ module Ameba::AST
     describe "#initialize" do
       it "creates a new flow expression" do
         node = as_node("return 22")
-        parent_node = as_node("def foo; return 22; end")
-        flow_expression = FlowExpression.new node, parent_node
+        flow_expression = FlowExpression.new node, false
         flow_expression.node.should_not be_nil
-        flow_expression.parent_node.should_not be_nil
+        flow_expression.in_loop?.should eq false
       end
 
       describe "#delegation" do
         it "delegates to_s to @node" do
           node = as_node("return 22")
-          parent_node = as_node("def foo; return 22; end")
-          flow_expression = FlowExpression.new node, parent_node
+          flow_expression = FlowExpression.new node, false
           flow_expression.to_s.should eq node.to_s
         end
 
         it "delegates location to @node" do
           node = as_node %(break if true)
-          parent_node = as_node("def foo; return 22 if true; end")
-          flow_expression = FlowExpression.new node, parent_node
+          flow_expression = FlowExpression.new node, false
           flow_expression.location.should eq node.location
         end
       end
 
-      describe "#find_unreachable_node" do
-        it "returns first unreachable node" do
+      describe "#unreachable_nodes" do
+        it "returns unreachable nodes" do
           nodes = as_nodes %(
             def foobar
               return
               a = 1
-              a + 1
+              a = 2
             end
           )
-          node = nodes.control_expression_nodes.first
-          assign_node = nodes.assign_nodes.first
-          def_node = nodes.def_nodes.first
-          flow_expression = FlowExpression.new node, def_node
-          flow_expression.find_unreachable_node.should eq assign_node
+          node = nodes.expressions_nodes.first
+          flow_expression = FlowExpression.new node, false
+          flow_expression.unreachable_nodes.should eq nodes.assign_nodes
         end
 
         it "returns nil if there is no unreachable node" do
@@ -50,10 +45,9 @@ module Ameba::AST
               return a
             end
           )
-          node = nodes.control_expression_nodes.first
-          def_node = nodes.def_nodes.first
-          flow_expression = FlowExpression.new node, def_node
-          flow_expression.find_unreachable_node.should eq nil
+          node = nodes.expressions_nodes.first
+          flow_expression = FlowExpression.new node, false
+          flow_expression.unreachable_nodes.empty?.should eq true
         end
       end
     end

--- a/spec/ameba/ast/visitors/flow_expression_visitor_spec.cr
+++ b/spec/ameba/ast/visitors/flow_expression_visitor_spec.cr
@@ -25,7 +25,7 @@ module Ameba::AST
           end
         end
       )
-      rule.expressions.size.should eq 2
+      rule.expressions.size.should eq 3
     end
 
     it "properly creates nested flow expressions" do
@@ -40,7 +40,7 @@ module Ameba::AST
           )
         end
       )
-      rule.expressions.size.should eq 3
+      rule.expressions.size.should eq 4
     end
 
     it "creates an expression for break" do

--- a/spec/ameba/ast/visitors/node_visitor_spec.cr
+++ b/spec/ameba/ast/visitors/node_visitor_spec.cr
@@ -5,14 +5,12 @@ module Ameba::AST
   source = Source.new ""
 
   describe NodeVisitor do
-    {% for name in NODES %}
-      describe "{{name}}" do
-        it "allow to visit {{name}} node" do
-          visitor = NodeVisitor.new rule, source
-          nodes = Crystal::Parser.new("").parse
-          nodes.accept visitor
-        end
+    describe "visit" do
+      it "allow to visit ASTNode" do
+        visitor = NodeVisitor.new rule, source
+        nodes = Crystal::Parser.new("").parse
+        nodes.accept visitor
       end
-    {% end %}
+    end
   end
 end

--- a/spec/ameba/rule/lint/unreachable_code_spec.cr
+++ b/spec/ameba/rule/lint/unreachable_code_spec.cr
@@ -41,6 +41,23 @@ module Ameba::Rule::Lint
         subject.catch(s).should be_valid
       end
 
+      it "doesn't report if there is no else in if" do
+        s = Source.new %(
+          if a > 0
+            return :positive
+          end
+          :reachable
+        )
+        subject.catch(s).should be_valid
+      end
+
+      it "doesn't report return in on-line if" do
+        s = Source.new %(
+          return :positive if a > 0
+        )
+        subject.catch(s).should be_valid
+      end
+
       it "doesn't report if return is used in a block" do
         s = Source.new %(
           def foo
@@ -57,7 +74,7 @@ module Ameba::Rule::Lint
         subject.catch(s).should be_valid
       end
 
-      pending "reports if there is unreachable code after if-then-else" do
+      it "reports if there is unreachable code after if-then-else" do
         s = Source.new %(
           def foo
             if a > 0
@@ -71,7 +88,448 @@ module Ameba::Rule::Lint
         )
         subject.catch(s).should_not be_valid
         issue = s.issues.first
-        issue.location.to_s.should eq ":8:4"
+        issue.location.to_s.should eq ":8:3"
+      end
+
+      it "reports if there is unreachable code after if-then-else-if" do
+        s = Source.new %(
+          def foo
+            if a > 0
+              return :positive
+            elsif a != 0
+              return :negative
+            else
+              return :zero
+            end
+
+            :unreachable
+          end
+        )
+        subject.catch(s).should_not be_valid
+        issue = s.issues.first
+        issue.location.to_s.should eq ":10:3"
+      end
+
+      it "doesn't report if there is no unreachable code after if-then-else" do
+        s = Source.new %(
+          def foo
+            if a > 0
+              return :positive
+            else
+              return :negative
+            end
+          end
+        )
+        subject.catch(s).should be_valid
+      end
+
+      it "doesn't report if there is no unreachable in inner branch" do
+        s = Source.new %(
+          def foo
+            if a > 0
+              return :positive if a != 1
+            else
+              return :negative
+            end
+
+            :not_unreachable
+          end
+        )
+        subject.catch(s).should be_valid
+      end
+
+      it "doesn't report if there is no unreachable in exception handler" do
+        s = Source.new %(
+          def foo
+            puts :bar
+          rescue Exception
+            raise "Error!"
+          end
+        )
+        subject.catch(s).should be_valid
+      end
+
+      it "doesn't report if there is multiple conditions with return" do
+        s = Source.new %(
+          if :foo
+            if :bar
+              return :foobar
+            else
+              return :foobaz
+            end
+          elsif :fox
+            return :foofox
+          end
+
+          return :reachable
+        )
+        subject.catch(s).should be_valid
+      end
+
+      it "reports if there is unreachable code after unless" do
+        s = Source.new %(
+          unless :foo
+            return :bar
+          else
+            return :foo
+          end
+
+          :unreachable
+        )
+        subject.catch(s).should_not be_valid
+        issue = s.issues.first
+        issue.location.to_s.should eq ":7:1"
+      end
+
+      it "doesn't report if there is no unreachable code after unless" do
+        s = Source.new %(
+          unless :foo
+            return :bar
+          end
+
+          :reachable
+        )
+        subject.catch(s).should be_valid
+      end
+    end
+
+    context "binary op" do
+      it "reports unreachable code in a binary operator" do
+        s = Source.new %(
+          (return 22) && puts "a"
+        )
+        subject.catch(s).should_not be_valid
+
+        issue = s.issues.first
+        issue.location.to_s.should eq ":1:16"
+      end
+
+      it "reports unreachable code in inner binary operator" do
+        s = Source.new %(
+          do_something || (return 22) && puts "a"
+        )
+        subject.catch(s).should_not be_valid
+
+        issue = s.issues.first
+        issue.location.to_s.should eq ":1:32"
+      end
+
+      it "reports unreachable code after the binary op" do
+        s = Source.new %(
+          (return 22) && break
+          :unreachable
+        )
+        subject.catch(s).should_not be_valid
+
+        issue = s.issues.first
+        issue.location.to_s.should eq ":2:1"
+      end
+
+      it "doesn't report if return is not the right" do
+        s = Source.new %(
+          puts "a" && return
+        )
+        subject.catch(s).should be_valid
+      end
+
+      it "doesn't report unreachable code in multiple binary expressions" do
+        s = Source.new %(
+          foo || bar || baz
+        )
+        subject.catch(s).should be_valid
+      end
+    end
+
+    context "case" do
+      it "reports if there is unreachable code after case" do
+        s = Source.new %(
+          def foo
+            case cond
+            when 1
+              something
+              return
+            when 2
+              something2
+              return
+            else
+              something3
+              return
+            end
+            :unreachable
+          end
+        )
+        subject.catch(s).should_not be_valid
+        issue = s.issues.first
+        issue.location.to_s.should eq ":13:3"
+      end
+
+      it "doesn't report if case does not have else" do
+        s = Source.new %(
+          def foo
+            case cond
+            when 1
+              something
+              return
+            when 2
+              something2
+              return
+            end
+            :reachable
+          end
+        )
+        subject.catch(s).should be_valid
+      end
+
+      it "doesn't report if one when does not return" do
+        s = Source.new %(
+          def foo
+            case cond
+            when 1
+              something
+              return
+            when 2
+              something2
+            else
+              something3
+              return
+            end
+            :reachable
+          end
+        )
+        subject.catch(s).should be_valid
+      end
+    end
+
+    context "exception handler" do
+      it "reports unreachable code if it returns in body and rescues" do
+        s = Source.new %(
+          def foo
+            begin
+              return false
+            rescue Error
+              return false
+            rescue Exception
+              return false
+            end
+            :unreachable
+          end
+        )
+        subject.catch(s).should_not be_valid
+
+        issue = s.issues.first
+        issue.location.to_s.should eq ":9:3"
+      end
+
+      it "reports unreachable code if it returns in rescues and else" do
+        s = Source.new %(
+          def foo
+            begin
+              do_something
+            rescue Error
+              return :error
+            else
+              return true
+            end
+            :unreachable
+          end
+        )
+        subject.catch(s).should_not be_valid
+
+        issue = s.issues.first
+        issue.location.to_s.should eq ":9:3"
+      end
+
+      it "doesn't report if there is no else and ensure doesn't return" do
+        s = Source.new %(
+          def foo
+            begin
+              return false
+            rescue Error
+              puts "error"
+            rescue Exception
+              return false
+            end
+            :reachable
+          end
+        )
+        subject.catch(s).should be_valid
+      end
+
+      it "doesn't report if there is no else and body doesn't return" do
+        s = Source.new %(
+          def foo
+            begin
+              do_something
+            rescue Error
+              return true
+            rescue Exception
+              return false
+            end
+            :reachable
+          end
+        )
+        subject.catch(s).should be_valid
+      end
+
+      it "doesn't report if there is else and ensure doesn't return" do
+        s = Source.new %(
+          def foo
+            begin
+              do_something
+            rescue Error
+              puts "yo"
+            else
+              return true
+            end
+            :reachable
+          end
+        )
+        subject.catch(s).should be_valid
+      end
+
+      it "doesn't report if there is else and it doesn't return" do
+        s = Source.new %(
+          def foo
+            begin
+              do_something
+            rescue Error
+              return false
+            else
+              puts "yo"
+            end
+            :reachable
+          end
+        )
+        subject.catch(s).should be_valid
+      end
+
+      it "reports if there is unreachable code in rescue" do
+        s = Source.new %(
+          def method
+          rescue
+            return 22
+            :unreachable
+          end
+        )
+
+        subject.catch(s).should_not be_valid
+
+        issue = s.issues.first
+        issue.location.to_s.should eq ":4:3"
+      end
+    end
+
+    context "while/until" do
+      it "reports if there is unreachable code after while" do
+        s = Source.new %(
+          def method
+            while something
+              if :foo
+                return :foo
+              else
+                return :foobar
+              end
+            end
+            :unreachable
+          end
+        )
+
+        subject.catch(s).should_not be_valid
+
+        issue = s.issues.first
+        issue.location.to_s.should eq ":9:3"
+      end
+
+      it "reports if there is unreachable code after until" do
+        s = Source.new %(
+          def method
+            until something
+              if :foo
+                return :foo
+              else
+                return :foobar
+              end
+            end
+            :unreachable
+          end
+        )
+
+        subject.catch(s).should_not be_valid
+
+        issue = s.issues.first
+        issue.location.to_s.should eq ":9:3"
+      end
+
+      it "doesn't report if there is reachable code after while with break" do
+        s = Source.new %(
+          while something
+            break
+          end
+          :reachable
+        )
+
+        subject.catch(s).should be_valid
+      end
+    end
+
+    context "rescue" do
+      it "reports unreachable code in rescue" do
+        s = Source.new %(
+          begin
+
+          rescue e
+            raise e
+            :unreachable
+          end
+        )
+
+        subject.catch(s).should_not be_valid
+
+        issue = s.issues.first
+        issue.location.to_s.should eq ":5:3"
+      end
+
+      it "doesn't report if there is no unreachable code in rescue" do
+        s = Source.new %(
+          begin
+
+          rescue e
+            raise e
+          end
+        )
+
+        subject.catch(s).should be_valid
+      end
+    end
+
+    context "when" do
+      it "reports unreachable code in when" do
+        s = Source.new %(
+          case
+          when valid?
+            return 22
+            :unreachable
+          else
+
+          end
+        )
+
+        subject.catch(s).should_not be_valid
+
+        issue = s.issues.first
+        issue.location.to_s.should eq ":4:3"
+      end
+
+      it "doesn't report if there is no unreachable code in when" do
+        s = Source.new %(
+          case
+          when valid?
+            return 22
+          else
+          end
+        )
+
+        subject.catch(s).should be_valid
       end
     end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -129,7 +129,7 @@ module Ameba
       Crystal::If,
       Crystal::While,
       Crystal::MacroLiteral,
-      Crystal::ControlExpression,
+      Crystal::Expressions,
     ]
 
     def initialize(node)

--- a/src/ameba/ast/branchable.cr
+++ b/src/ameba/ast/branchable.cr
@@ -1,7 +1,7 @@
 module Ameba::AST
   # A generic entity to represent a branchable Crystal node.
   # For example, `Crystal::If`, `Crystal::Unless`, `Crystal::While`
-  # are branchable.
+  # are branchables.
   #
   # ```
   # white a > 100 # Branchable A

--- a/src/ameba/rule/lint/unreachable_code.cr
+++ b/src/ameba/rule/lint/unreachable_code.cr
@@ -43,6 +43,8 @@ module Ameba::Rule::Lint
   # ```
   #
   struct UnreachableCode < Base
+    include AST::Util
+
     properties do
       description "Reports unreachable code"
     end
@@ -54,7 +56,7 @@ module Ameba::Rule::Lint
     end
 
     def test(source, node, flow_expression : AST::FlowExpression)
-      if unreachable_node = flow_expression.find_unreachable_node
+      if unreachable_node = flow_expression.unreachable_nodes.first?
         issue_for unreachable_node, MSG
       end
     end


### PR DESCRIPTION
This is a "spin-off" of #82 

This implementation utilizes analysis of control flow expressions while searching for the **unreachable code**.  For example, all these examples are now correctly reported:


```cr

if a > 0
  return :positive
else
  return :negative
end

:unreachable    # <--- can't be reached

```

```cr
if a > 0
  return :positive
elsif a != 0
  return :negative
else
  return :zero
end

:unreachable    # <--- can't be reached
```

```cr
if a > 0
  return :positive if a != 1
else
  return :negative
end

:not_unreachable  
```

```cr
case cond
when 1
  something
  return
when 2
  something2
  return
else
  something3
  return
end
:unreachable   # <--- can't be reached
```


```cr
begin
  return false
rescue Error
  return false
rescue e
  raise e
end
:unreachable  # <--- can't be reached
```

```cr
while something
  if :foo
    return :foo
  else
    return :foobar
  end
end
:unreachable # <--- can't be reached
```

```cr
while something
  break
  :unreachable # <--- can't be reached
end
```

```cr
while something
  break
end
:not_unreachable
```

[See specs](https://github.com/veelenga/ameba/blob/749739aa5d2859c535f10bb6407d86dd5c1dae57/spec/ameba/rule/lint/unreachable_code_spec.cr) for a full set of examples.







