### PR TITLE
Show affected code while using a default formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,19 @@ Inspecting 107 files.
 
 ...............F.....................F....................................................................
 
-src/ameba/rule/unneeded_disable_directive.cr:29:7
-Lint/UselessAssign: Useless assignment to variable `s`
-
-src/ameba/formatter/flycheck_formatter.cr:5:21
+src/ameba/formatter/flycheck_formatter.cr:4:33
 Lint/UnusedArgument: Unused argument `location`
+> source.issues.each do |e, location|
+                            ^
 
-Finished in 248.9 milliseconds
+src/ameba/formatter/base_formatter.cr:12:7
+Lint/UselessAssign: Useless assignment to variable `s`
+> return s += issues.size
+         ^
 
-107 inspected, 2 failures.
+Finished in 542.64 milliseconds
+
+129 inspected, 2 failures.
 
 ```
 

--- a/spec/ameba/cli/cmd_spec.cr
+++ b/spec/ameba/cli/cmd_spec.cr
@@ -62,6 +62,11 @@ module Ameba::Cli
         c.colors?.should be_false
       end
 
+      it "accepts --without-affected-code flag" do
+        c = Cli.parse_args %w(--without-affected-code)
+        c.without_affected_code?.should be_true
+      end
+
       it "doesn't disable colors by default" do
         c = Cli.parse_args %w(--all)
         c.colors?.should be_true

--- a/spec/ameba/formatter/dot_formatter_spec.cr
+++ b/spec/ameba/formatter/dot_formatter_spec.cr
@@ -50,6 +50,37 @@ module Ameba::Formatter
           log.should contain "NamedRuleError"
         end
 
+        it "writes affected code by default" do
+          output.clear
+          s = Source.new(%(
+            a = 22
+            puts a
+          )).tap do |source|
+            source.add_issue(DummyRule.new, {1, 5}, "DummyRuleError")
+          end
+          subject.finished [s]
+          log = output.to_s
+          log.should contain "> a = 22"
+          log.should contain "      \e[33m^\e[0m"
+        end
+
+        it "doesn't write affected code if it is disabled" do
+          output.clear
+          s = Source.new(%(
+            a = 22
+            puts a
+          )).tap do |source|
+            source.add_issue(DummyRule.new, {1, 5}, "DummyRuleError")
+          end
+
+          formatter = DotFormatter.new output
+          formatter.config[:without_affected_code] = true
+          formatter.finished [s]
+          log = output.to_s
+          log.should_not contain "> a = 22"
+          log.should_not contain "      \e[33m^\e[0m"
+        end
+
         it "does not write disabled issues" do
           s = Source.new ""
           s.add_issue(DummyRule.new, location: {1, 1},

--- a/src/ameba/cli/cmd.cr
+++ b/src/ameba/cli/cmd.cr
@@ -27,6 +27,7 @@ module Ameba::Cli
     property except : Array(String)?
     property? all = false
     property? colors = true
+    property? without_affected_code = false
   end
 
   def parse_args(args, opts = Opts.new)
@@ -68,6 +69,11 @@ module Ameba::Cli
         opts.config = ""
       end
 
+      parser.on("--without-affected-code",
+        "Stop showing affected code while using a default formatter") do
+        opts.without_affected_code = true
+      end
+
       parser.on("--no-color", "Disable colors") do
         opts.colors = false
       end
@@ -91,6 +97,7 @@ module Ameba::Cli
     if name = opts.formatter
       config.formatter = name
     end
+    config.formatter.config[:without_affected_code] = opts.without_affected_code?
   end
 
   private def print_version

--- a/src/ameba/formatter/base_formatter.cr
+++ b/src/ameba/formatter/base_formatter.cr
@@ -6,6 +6,7 @@ module Ameba::Formatter
   class BaseFormatter
     # TODO: allow other IOs
     getter output : IO::FileDescriptor | IO::Memory
+    getter config = {} of Symbol => String | Bool
 
     def initialize(@output = STDOUT)
     end

--- a/src/ameba/rule/layout/line_length.cr
+++ b/src/ameba/rule/layout/line_length.cr
@@ -22,7 +22,7 @@ module Ameba::Rule::Layout
       source.lines.each_with_index do |line, index|
         next unless line.size > max_length
 
-        issue_for({index + 1, line.size}, MSG)
+        issue_for({index + 1, max_length + 1}, MSG)
       end
     end
   end


### PR DESCRIPTION
We now able to show the affected code using a default formatter (`DotFormatter`). This feature can be disabled via `--without-affected-code` cli flag.

Example:

<img width="675" alt="screen shot 2018-12-12 at 21 46 46" src="https://user-images.githubusercontent.com/3624712/49894787-7991ac80-fe57-11e8-8f46-ba266f374091.png">
