### PR TITLE
Stop calculating cyclomatic complexity for methods which have Macro c…

### DIFF
--- a/spec/ameba/ast/visitors/counting_visitor_spec.cr
+++ b/spec/ameba/ast/visitors/counting_visitor_spec.cr
@@ -18,6 +18,32 @@ module Ameba::AST
         visitor.count.should eq 1
       end
 
+      it "is 1 if there is Macro::For" do
+        code = %(
+          def initialize()
+            {% for c in ALL_NODES %}
+              true || false
+            {% end %}
+          end
+        )
+        node = Crystal::Parser.new(code).parse
+        visitor = CountingVisitor.new node
+        visitor.count.should eq 1
+      end
+
+      it "is 1 if there is Macro::If" do
+        code = %(
+          def initialize()
+            {% if foo.bar? %}
+              true || false
+            {% end %}
+          end
+        )
+        node = Crystal::Parser.new(code).parse
+        visitor = CountingVisitor.new node
+        visitor.count.should eq 1
+      end
+
       {% for pair in [
                        {code: "if true; end", description: "conditional"},
                        {code: "while true; end", description: "while loop"},

--- a/src/ameba/ast/visitors/counting_visitor.cr
+++ b/src/ameba/ast/visitors/counting_visitor.cr
@@ -1,10 +1,12 @@
 module Ameba::AST
   # AST Visitor that counts occurrences of certain keywords
   class CountingVisitor < Crystal::Visitor
-    @complexity = 1
+    DEFAULT_COMPLEXITY = 1
+    getter macro_condition = false
 
     # Creates a new counting visitor
     def initialize(@scope : Crystal::ASTNode)
+      @complexity = DEFAULT_COMPLEXITY
     end
 
     # :nodoc:
@@ -24,8 +26,14 @@ module Ameba::AST
     {% for node in %i(if while until rescue when or and) %}
       # :nodoc:
       def visit(node : Crystal::{{ node.id.capitalize }})
-        @complexity += 1
+        @complexity += 1 unless macro_condition
       end
     {% end %}
+
+    def visit(node : Crystal::MacroIf | Crystal::MacroFor)
+      @macro_condition = true
+      @complexity = DEFAULT_COMPLEXITY
+      false
+    end
   end
 end


### PR DESCRIPTION
…onditions

Fixes #98

We skip cyclomatic complexity for methods which contain `Macro::If/Macro::For` nodes. Because macros usually can't be splitted out into multiple methods.  

/cc @Blacksmoke16