### PR TITLE
Feat/severity

### DIFF
--- a/spec/ameba/cli/cmd_spec.cr
+++ b/spec/ameba/cli/cmd_spec.cr
@@ -114,6 +114,29 @@ module Ameba::Cli
         end
       end
 
+      context "--fail-level" do
+        it "configures fail level Refactoring" do
+          c = Cli.parse_args %w(--fail-level refactoring)
+          c.fail_level.should eq Severity::Refactoring
+        end
+
+        it "configures fail level Warning" do
+          c = Cli.parse_args %w(--fail-level Warning)
+          c.fail_level.should eq Severity::Warning
+        end
+
+        it "configures fail level Error" do
+          c = Cli.parse_args %w(--fail-level error)
+          c.fail_level.should eq Severity::Error
+        end
+
+        it "raises if fail level is incorrect" do
+          expect_raises(Exception, "Incorrect severity name JohnDoe") do
+            Cli.parse_args %w(--fail-level JohnDoe)
+          end
+        end
+      end
+
       it "accepts unknown args as globs" do
         c = Cli.parse_args %w(source1.cr source2.cr)
         c.globs.should eq %w(source1.cr source2.cr)

--- a/spec/ameba/formatter/dot_formatter_spec.cr
+++ b/spec/ameba/formatter/dot_formatter_spec.cr
@@ -64,6 +64,19 @@ module Ameba::Formatter
           log.should contain "      \e[33m^\e[0m"
         end
 
+        it "writes severity" do
+          output.clear
+          s = Source.new(%(
+            a = 22
+            puts a
+          )).tap do |source|
+            source.add_issue(DummyRule.new, {1, 5}, "DummyRuleError")
+          end
+          subject.finished [s]
+          log = output.to_s
+          log.should contain "[R]"
+        end
+
         it "doesn't write affected code if it is disabled" do
           output.clear
           s = Source.new(%(

--- a/spec/ameba/formatter/explain_formatter_spec.cr
+++ b/spec/ameba/formatter/explain_formatter_spec.cr
@@ -50,6 +50,7 @@ module Ameba
         source = Source.new "a = 42", "source.cr"
         output = explanation(source)
         output.should contain "RULE INFO"
+        output.should contain "Refactoring"
         output.should contain "Ameba/ErrorRule"
         output.should contain "Always adds an error at 1:1"
       end

--- a/spec/ameba/formatter/flycheck_formatter_spec.cr
+++ b/spec/ameba/formatter/flycheck_formatter_spec.cr
@@ -22,7 +22,7 @@ module Ameba::Formatter
         subject = flycheck
         subject.source_finished s
         subject.output.to_s.should eq(
-          "source.cr:1:2: E: [#{DummyRule.rule_name}] message\n"
+          "source.cr:1:2: R: [#{DummyRule.rule_name}] message\n"
         )
       end
 
@@ -32,7 +32,7 @@ module Ameba::Formatter
         subject = flycheck
         subject.source_finished s
         subject.output.to_s.should eq(
-          "source.cr:1:2: E: [#{DummyRule.rule_name}] multi line\n"
+          "source.cr:1:2: R: [#{DummyRule.rule_name}] multi line\n"
         )
       end
 

--- a/spec/ameba/formatter/json_formatter_spec.cr
+++ b/spec/ameba/formatter/json_formatter_spec.cr
@@ -37,6 +37,14 @@ module Ameba
         result["sources"][0]["issues"][0]["rule_name"].should eq DummyRule.rule_name
       end
 
+      it "shows severity" do
+        s = Source.new ""
+        s.add_issue DummyRule.new, {1, 2}, "message"
+
+        result = get_result [s]
+        result["sources"][0]["issues"][0]["severity"].should eq "Refactoring"
+      end
+
       it "shows a message" do
         s = Source.new ""
         s.add_issue DummyRule.new, {1, 2}, "message"

--- a/spec/ameba/formatter/todo_formatter_spec.cr
+++ b/spec/ameba/formatter/todo_formatter_spec.cr
@@ -43,6 +43,10 @@ module Ameba
         create_todo.should contain "DummyRule"
       end
 
+      it "creates a todo with severity" do
+        create_todo.should contain "Refactoring"
+      end
+
       it "creates a todo with problems count" do
         create_todo.should contain "Problems found: 1"
       end

--- a/spec/ameba/rule/lint/syntax_spec.cr
+++ b/spec/ameba/rule/lint/syntax_spec.cr
@@ -33,5 +33,9 @@ module Ameba::Rule::Lint
       issue.location.to_s.should eq "source.cr:1:11"
       issue.message.should eq "unexpected token: end (expected ';' or newline)"
     end
+
+    it "has highest severity" do
+      subject.severity.should eq Severity::Error
+    end
   end
 end

--- a/spec/ameba/severity_spec.cr
+++ b/spec/ameba/severity_spec.cr
@@ -1,0 +1,79 @@
+require "../spec_helper"
+
+module Ameba
+  describe Severity do
+    describe ".default" do
+      it "returns default severity" do
+        Severity.default.should eq Severity::Refactoring
+      end
+    end
+
+    describe ".from_name" do
+      it "creates error severity by name" do
+        Severity.from_name("Error").should eq Severity::Error
+      end
+
+      it "creates warning severity by name" do
+        Severity.from_name("Warning").should eq Severity::Warning
+      end
+
+      it "creates refactoring severity by name" do
+        Severity.from_name("Refactoring").should eq Severity::Refactoring
+      end
+
+      it "raises when name is incorrect" do
+        expect_raises(Exception, "Incorrect severity name BadName. Try one of [Error, Warning, Refactoring]") do
+          Severity.from_name("BadName")
+        end
+      end
+    end
+  end
+
+  struct SeverityConvertable
+    YAML.mapping(
+      severity: { type: Severity, converter: SeverityYamlConverter }
+    )
+  end
+
+  describe SeverityYamlConverter do
+    describe ".from_yaml" do
+      it "converts from yaml to Severity::Error" do
+        yaml = { severity: "error" }.to_yaml
+        converted = SeverityConvertable.from_yaml(yaml)
+        converted.severity.should eq Severity::Error
+      end
+
+      it "converts from yaml to Severity::Warning" do
+        yaml = { severity: "warning" }.to_yaml
+        converted = SeverityConvertable.from_yaml(yaml)
+        converted.severity.should eq Severity::Warning
+      end
+
+      it "converts from yaml to Severity::Refactoring" do
+        yaml = { severity: "refactoring" }.to_yaml
+        converted = SeverityConvertable.from_yaml(yaml)
+        converted.severity.should eq Severity::Refactoring
+      end
+    end
+
+    describe ".to_yaml" do
+      it "converts Severity::Error to yaml" do
+        yaml = { severity: "error" }.to_yaml
+        converted = SeverityConvertable.from_yaml(yaml).to_yaml
+        converted.should eq "---\nseverity: Error\n"
+      end
+
+      it "converts Severity::Warning to yaml" do
+        yaml = { severity: "warning" }.to_yaml
+        converted = SeverityConvertable.from_yaml(yaml).to_yaml
+        converted.should eq "---\nseverity: Warning\n"
+      end
+
+      it "converts Severity::Refactoring to yaml" do
+        yaml = { severity: "refactoring" }.to_yaml
+        converted = SeverityConvertable.from_yaml(yaml).to_yaml
+        converted.should eq "---\nseverity: Refactoring\n"
+      end
+    end
+  end
+end

--- a/spec/ameba/severity_spec.cr
+++ b/spec/ameba/severity_spec.cr
@@ -2,12 +2,6 @@ require "../spec_helper"
 
 module Ameba
   describe Severity do
-    describe ".default" do
-      it "returns default severity" do
-        Severity.default.should eq Severity::Refactoring
-      end
-    end
-
     describe ".from_name" do
       it "creates error severity by name" do
         Severity.from_name("Error").should eq Severity::Error
@@ -31,46 +25,60 @@ module Ameba
 
   struct SeverityConvertable
     YAML.mapping(
-      severity: { type: Severity, converter: SeverityYamlConverter }
+      severity: {type: Severity, converter: SeverityYamlConverter}
     )
   end
 
   describe SeverityYamlConverter do
     describe ".from_yaml" do
       it "converts from yaml to Severity::Error" do
-        yaml = { severity: "error" }.to_yaml
+        yaml = {severity: "error"}.to_yaml
         converted = SeverityConvertable.from_yaml(yaml)
         converted.severity.should eq Severity::Error
       end
 
       it "converts from yaml to Severity::Warning" do
-        yaml = { severity: "warning" }.to_yaml
+        yaml = {severity: "warning"}.to_yaml
         converted = SeverityConvertable.from_yaml(yaml)
         converted.severity.should eq Severity::Warning
       end
 
       it "converts from yaml to Severity::Refactoring" do
-        yaml = { severity: "refactoring" }.to_yaml
+        yaml = {severity: "refactoring"}.to_yaml
         converted = SeverityConvertable.from_yaml(yaml)
         converted.severity.should eq Severity::Refactoring
+      end
+
+      it "raises if severity is not a scalar" do
+        yaml = {severity: {refactoring: true}}.to_yaml
+        expect_raises(Exception, "Severity must be a scalar") do
+          SeverityConvertable.from_yaml(yaml)
+        end
+      end
+
+      it "raises if severity has a wrong type" do
+        yaml = {severity: [1, 2, 3]}.to_yaml
+        expect_raises(Exception, "Severity must be a scalar") do
+          SeverityConvertable.from_yaml(yaml)
+        end
       end
     end
 
     describe ".to_yaml" do
       it "converts Severity::Error to yaml" do
-        yaml = { severity: "error" }.to_yaml
+        yaml = {severity: "error"}.to_yaml
         converted = SeverityConvertable.from_yaml(yaml).to_yaml
         converted.should eq "---\nseverity: Error\n"
       end
 
       it "converts Severity::Warning to yaml" do
-        yaml = { severity: "warning" }.to_yaml
+        yaml = {severity: "warning"}.to_yaml
         converted = SeverityConvertable.from_yaml(yaml).to_yaml
         converted.should eq "---\nseverity: Warning\n"
       end
 
       it "converts Severity::Refactoring to yaml" do
-        yaml = { severity: "refactoring" }.to_yaml
+        yaml = {severity: "refactoring"}.to_yaml
         converted = SeverityConvertable.from_yaml(yaml).to_yaml
         converted.should eq "---\nseverity: Refactoring\n"
       end

--- a/spec/ameba/severity_spec.cr
+++ b/spec/ameba/severity_spec.cr
@@ -2,6 +2,26 @@ require "../spec_helper"
 
 module Ameba
   describe Severity do
+    describe "#symbol" do
+      it "returns the symbol for each severity in the enum" do
+        Severity.values.each do |severity|
+          severity.symbol.should_not be_nil
+        end
+      end
+
+      it "returns symbol for Error" do
+        Severity::Error.symbol.should eq 'E'
+      end
+
+      it "returns symbol for Warning" do
+        Severity::Warning.symbol.should eq 'W'
+      end
+
+      it "returns symbol for Refactoring" do
+        Severity::Refactoring.symbol.should eq 'R'
+      end
+    end
+
     describe ".from_name" do
       it "creates error severity by name" do
         Severity.from_name("Error").should eq Severity::Error

--- a/src/ameba/cli/cmd.cr
+++ b/src/ameba/cli/cmd.cr
@@ -9,6 +9,7 @@ module Ameba::Cli
     opts = parse_args args
     config = Config.load opts.config, opts.colors?
     config.globs = opts.globs
+    config.severity = opts.fail_level.not_nil! if opts.fail_level
 
     configure_formatter(config, opts)
     configure_rules(config, opts)
@@ -32,6 +33,7 @@ module Ameba::Cli
     property only : Array(String)?
     property except : Array(String)?
     property location_to_explain : NamedTuple(file: String, line: Int32, column: Int32)?
+    property fail_level : Severity?
     property? all = false
     property? colors = true
     property? without_affected_code = false
@@ -80,6 +82,10 @@ module Ameba::Cli
         "Generate a configuration file acting as a TODO list") do
         opts.formatter = :todo
         opts.config = ""
+      end
+
+      parser.on("--fail-level SEVERITY", "Change the level of failure to exit. Defaults to Refactoring") do |level|
+        opts.fail_level = Severity.from_name(level)
       end
 
       parser.on("-e", "--explain PATH:line:column",

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -227,6 +227,11 @@ class Ameba::Config
         {% properties["enabled".id] = {key: "Enabled", default: true, type: Bool} %}
       {% end %}
 
+      {% if properties["severity".id] == nil %}
+        {% default = @type.name.starts_with?("Ameba::Rule::Lint") ? "Severity::Warning".id : "Severity::Refactoring".id %}
+        {% properties["severity".id] = {key: "Severity", default: default, type: Severity, converter: SeverityYamlConverter} %}
+      {% end %}
+
       {% if properties["excluded".id] == nil %}
         {% properties["excluded".id] = {key: "Excluded", type: "Array(String)?".id} %}
       {% end %}

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -193,6 +193,12 @@ class Ameba::Config
         {% key = name.camelcase.stringify %}
         {% value = df[:value] %}
         {% type = df[:type] %}
+        {% converter = nil %}
+
+        {% if key == "Severity" %}
+          {% type = Severity %}
+          {% converter = SeverityYamlConverter %}
+        {% end %}
 
         {% if type == nil %}
           {% if value.is_a? BoolLiteral %}
@@ -214,7 +220,7 @@ class Ameba::Config
           {% type = Nil if type == nil %}
         {% end %}
 
-        {% properties[name] = {key: key, default: value, type: type} %}
+        {% properties[name] = {key: key, default: value, type: type, converter: converter} %}
       {% end %}
 
       {% if properties["enabled".id] == nil %}

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -28,6 +28,7 @@ class Ameba::Config
   setter formatter : Formatter::BaseFormatter?
   setter globs : Array(String)?
   getter rules : Array(Rule::Base)
+  property severity = Severity::Refactoring
 
   @rule_groups : Hash(String, Array(Rule::Base))
 

--- a/src/ameba/formatter/dot_formatter.cr
+++ b/src/ameba/formatter/dot_formatter.cr
@@ -35,7 +35,7 @@ module Ameba::Formatter
           next if (location = issue.location).nil?
 
           output << "#{location}\n".colorize(:cyan)
-          output << "#{issue.rule.name}: #{issue.message}\n".colorize(:red)
+          output << "[#{issue.rule.severity.symbol}] #{issue.rule.name}: #{issue.message}\n".colorize(:red)
 
           if show_affected_code && (code = affected_code(source, location))
             output << code

--- a/src/ameba/formatter/explain_formatter.cr
+++ b/src/ameba/formatter/explain_formatter.cr
@@ -57,7 +57,7 @@ module Ameba::Formatter
 
       if rule.responds_to?(:description)
         output_title "RULE INFO"
-        output_paragraph [rule.name, rule.description]
+        output_paragraph [rule.severity.to_s, rule.name, rule.description]
       end
 
       output_title "DETAILED DESCRIPTION"

--- a/src/ameba/formatter/flycheck_formatter.cr
+++ b/src/ameba/formatter/flycheck_formatter.cr
@@ -5,7 +5,7 @@ module Ameba::Formatter
         next if e.disabled?
         if loc = e.location
           output.printf "%s:%d:%d: %s: [%s] %s\n",
-            source.path, loc.line_number, loc.column_number, "E",
+            source.path, loc.line_number, loc.column_number, e.rule.severity.symbol,
             e.rule.name, e.message.gsub("\n", " ")
         end
       end

--- a/src/ameba/formatter/json_formatter.cr
+++ b/src/ameba/formatter/json_formatter.cr
@@ -25,6 +25,7 @@ module Ameba::Formatter
   #           },
   #           "message":   "Useless assignment to variable `a`",
   #           "rule_name": "UselessAssign",
+  #           "severity":  "Refactoring",
   #         },
   #         {
   #           "location": {
@@ -49,6 +50,7 @@ module Ameba::Formatter
   #           },
   #           "message":   "Useless assignment to variable `a`",
   #           "rule_name": "UselessAssign",
+  #           "severity":  "Refactoring",
   #         },
   #       ],
   #       "path": "src/ameba/formatter/json_formatter.cr",
@@ -75,7 +77,7 @@ module Ameba::Formatter
 
       source.issues.each do |e|
         next if e.disabled?
-        json_source.issues << AsJSON::Issue.new(e.rule.name, e.location, e.end_location, e.message)
+        json_source.issues << AsJSON::Issue.new(e.rule.name, e.rule.severity.to_s, e.location, e.end_location, e.message)
         @result.summary.issues_count += 1
       end
 
@@ -107,12 +109,14 @@ module Ameba::Formatter
 
     record Issue,
       rule_name : String,
+      severity : String,
       location : Crystal::Location?,
       end_location : Crystal::Location?,
       message : String do
       def to_json(json)
         json.object do
           json.field :rule_name, rule_name
+          json.field :severity, severity
           json.field :message, message
           json.field :location,
             {line: location.try &.line_number, column: location.try &.column_number}

--- a/src/ameba/rule/lint/syntax.cr
+++ b/src/ameba/rule/lint/syntax.cr
@@ -20,7 +20,10 @@ module Ameba::Rule::Lint
   # ```
   #
   struct Syntax < Base
-    getter description = "Reports invalid Crystal syntax."
+    properties do
+      description "Reports invalid Crystal syntax"
+      severity Severity::Error
+    end
 
     def test(source)
       source.ast

--- a/src/ameba/severity.cr
+++ b/src/ameba/severity.cr
@@ -4,6 +4,22 @@ module Ameba
     Warning
     Refactoring
 
+    # Returns a symbol uniquely indicating severity.
+    #
+    # ```
+    # Severity::Warning.symbol # => 'W'
+    # ```
+    def symbol
+      to_s[0]
+    end
+
+    # Creates Severity by the name.
+    #
+    # ```
+    # Severity.from_name('refactoring') # => Severity::Refactoring
+    # Severity.from_name('foo-bar')     # => Exception: Incorrect severity name..
+    # ```
+    #
     def self.from_name(name : String)
       case name.downcase
       when "error"
@@ -18,6 +34,7 @@ module Ameba
     end
   end
 
+  # Converter for `YAML.mapping` which converts severity enum to and from YAML.
   class SeverityYamlConverter
     def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
       unless node.is_a?(YAML::Nodes::Scalar)

--- a/src/ameba/severity.cr
+++ b/src/ameba/severity.cr
@@ -1,0 +1,43 @@
+module Ameba
+  enum Severity
+    Error
+    Warning
+    Refactoring
+
+    def self.default
+      Refactoring
+    end
+
+    def self.from_name(name : String)
+      case name.downcase
+      when "error"
+        Error
+      when "warning"
+        Warning
+      when "refactoring"
+        Refactoring
+      else
+        raise "Incorrect severity name #{name}. Try one of #{Severity.values}"
+      end
+    end
+  end
+
+  class SeverityYamlConverter
+    def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+      unless node.is_a?(YAML::Nodes::Scalar)
+        raise "Severity must be a scalar, not #{node.class}"
+      end
+
+      case value = node.value
+      when String then Severity.from_name(value)
+      when Nil    then nil
+      else
+        raise "Incorrect severity: #{value}"
+      end
+    end
+
+    def self.to_yaml(value : Severity, yaml : YAML::Nodes::Builder)
+      yaml.scalar value.to_s
+    end
+  end
+end

--- a/src/ameba/severity.cr
+++ b/src/ameba/severity.cr
@@ -4,10 +4,6 @@ module Ameba
     Warning
     Refactoring
 
-    def self.default
-      Refactoring
-    end
-
     def self.from_name(name : String)
       case name.downcase
       when "error"
@@ -37,7 +33,7 @@ module Ameba
     end
 
     def self.to_yaml(value : Severity, yaml : YAML::Nodes::Builder)
-      yaml.scalar value.to_s
+      yaml.scalar value
     end
   end
 end

--- a/src/ameba/severity.cr
+++ b/src/ameba/severity.cr
@@ -21,16 +21,9 @@ module Ameba
     # ```
     #
     def self.from_name(name : String)
-      case name.downcase
-      when "error"
-        Error
-      when "warning"
-        Warning
-      when "refactoring"
-        Refactoring
-      else
-        raise "Incorrect severity name #{name}. Try one of #{Severity.values}"
-      end
+      parse(name)
+    rescue ArgumentError
+      raise "Incorrect severity name #{name}. Try one of #{Severity.values}"
     end
   end
 


### PR DESCRIPTION
Should close #39.

- [x] Each rule should have it's own severity
- [x] Severity could be one of `error`, `warning`, `refactoring`
- [x] Severity should be inferred by the name and category by default. For example:
  
  * [Layout/*](https://github.com/veelenga/ameba/tree/master/src/ameba/rule/layout) - refactoring
  * [Metrics/*](https://github.com/veelenga/ameba/tree/master/src/ameba/rule/metrics) - refactoring
  * [Performance/*](https://github.com/veelenga/ameba/tree/master/src/ameba/rule/performance) - refactoring
  * [Style/*](https://github.com/veelenga/ameba/tree/master/src/ameba/rule/style) - refactoring
  * [Lint/*](https://github.com/veelenga/ameba/tree/master/src/ameba/rule/lint) - warning
  * [Lint/Syntax](https://github.com/veelenga/ameba/blob/master/src/ameba/rule/lint/syntax.cr) - error

for now we will have only one rule with `error` severity but it can be changed later.
  
- [x] Severity should be customizable via config
- [x] User should be able to run only rules which have some severity: `ameba --fail-level SEVERITY`

For example:

* `ameba --fail-level refactoring` - default and currently existed behaviour. Fails if at least one rule of severity `refactoring`, `warning` or `error` fails
* `ameba --fail-level warning` - fails if at least one rule of severity `warning` or `error` fails
* `ameba --fail-level error` - fails if at least one rule of severity `error` fails

- [x] User should see an error if he provides inappropriate severity

### Usage example:

```sh
$ ameba                                                                                                                                                                                                          
Inspecting 143 files.

...........................................F...................................................................................................

spec/ameba/formatter/flycheck_formatter_spec.cr:12:9
[W] Lint/UselessAssign: Useless assignment to variable `test`
> test = 1
  ^
Finished in 409.4 milliseconds

143 inspected, 1 failure.
$ echo $?                                                                                                                                                                                                       
1

$ ameba --fail-level Error                                                                                                                                                                                        
Inspecting 143 files.

...........................................F...................................................................................................

spec/ameba/formatter/flycheck_formatter_spec.cr:12:9
[W] Lint/UselessAssign: Useless assignment to variable `test`
> test = 1
  ^
Finished in 408.64 milliseconds

143 inspected, 1 failure.
$ echo $?                                                                                                                                                                                                         
0
```

### Formatters

#### Dot Formatter
<img width="1010" alt="Screen Shot 2019-04-14 at 16 49 17" src="https://user-images.githubusercontent.com/3624712/56093853-2186b780-5ed6-11e9-9120-7eedbab6453b.png">

#### JSON Formatter
<img width="818" alt="Screen Shot 2019-04-14 at 16 51 57" src="https://user-images.githubusercontent.com/3624712/56093856-264b6b80-5ed6-11e9-8c8f-0a2aaf607862.png">

#### Flycheck Formatter

<img width="809" alt="Screen Shot 2019-04-14 at 16 54 34" src="https://user-images.githubusercontent.com/3624712/56093867-43803a00-5ed6-11e9-93c6-4714863a5bbf.png">



#### Explain Formatter
<img width="621" alt="Screen Shot 2019-04-14 at 16 53 16" src="https://user-images.githubusercontent.com/3624712/56093858-277c9880-5ed6-11e9-907a-3aca4ddc91d7.png">
