### PR TITLE
Let it be extensible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ install: build
 bin: build
 	mkdir -p $(SHARD_BIN)
 	cp ./bin/ameba $(SHARD_BIN)
+run_file:
+	cp -r ./bin/ameba.cr $(SHARD_BIN)
 test: build
 	$(CRYSTAL_BIN) spec
 	./bin/ameba --all

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ install:
   - shards install
 script:
   - crystal spec
-  - bin/ameba
+  - crystal bin/ameba.cr
 ```
 
 Using this config Ameba will inspect files just after the specs run. Travis will also fail

--- a/bin/ameba.cr
+++ b/bin/ameba.cr
@@ -1,0 +1,7 @@
+# Require ameba cli which starts the inspection.
+require "ameba/cli"
+
+# Require ameba extensions here which are added as project dependencies.
+# Example:
+#
+# require "ameba-performance"

--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,8 @@ targets:
     main: src/cli.cr
 
 scripts:
-  postinstall: make bin
+  # TODO: remove pre-compiled executable in future releases
+  postinstall: make bin && make run_file
 
 executables:
   - ameba


### PR DESCRIPTION
### What

We would like to make Ameba more extensible. Meaning, the developer should be able to create an extension which includes some extra rules and the end user should be able to easily run/configure/disable Ameba's and extensions' rules in a single bundle. 

### Why

This solves two issues:

1. Ameba can be modulized (i.e. `ameba-performance`, `ameba-ecr`, `ameba-shardyml` etc.). So the end user will choose whether to include that or another standard module/extension.

2. Any other developer can create a special bunch or rules needed for his concrete project and reuse Ameba's engine.

### How

1. We stop shipping an executable as a post-install action in `shards install` task. (This is still enabled for backward compatibility and will be removed in future releases).
2. Instead, we copy a [run file](https://github.com/veelenga/ameba/blob/5d258cd3b16ec67f5011d06eb2e57482399321ff/bin/ameba.cr) in a post-install action.
3. The file can be managed by the end-user, who can require that or another module (depends on project dependencies)
4. Inspection starts using `crystal bin/ameba.cr` file, which requires ameba + extensions. This will run the build which includes an extended set of rules (already handled by Ameba). 

### Examples

```crystal
# your_shard/bin/ameba.cr

require "ameba-performance"
require "ameba-ecr"
require "ameba-shardyml"
require "ameba/cli"
```

This command will start the inspection which includes standard rules + external rules:

```sh
$ crystal bin/ameba.cr
$ crystal build bin/ameba.cr -o bin/ameba && bin/ameba
``` 