### PR TITLE
Allow named replacements in `expect_issue`

### DIFF
--- a/spec/ameba/rule/style/large_numbers_spec.cr
+++ b/spec/ameba/rule/style/large_numbers_spec.cr
@@ -5,9 +5,12 @@ module Ameba
 
   private def it_transforms(number, expected)
     it "transforms large number #{number}" do
-      s = Source.new number
-      Rule::Style::LargeNumbers.new.catch(s).should_not be_valid
-      s.issues.first.message.should contain expected
+      rule = Rule::Style::LargeNumbers.new
+
+      expect_issue rule, <<-CRYSTAL, number: number
+        number = %{number}
+               # ^{number} error: Large numbers should be written with underscores: #{expected}
+        CRYSTAL
     end
   end
 
@@ -118,7 +121,7 @@ module Ameba
       issue = s.issues.first
       issue.rule.should_not be_nil
       issue.location.to_s.should eq "source.cr:1:1"
-      issue.end_location.should be_nil
+      issue.end_location.to_s.should eq "source.cr:1:7"
       issue.message.should match /1_200_000/
     end
 

--- a/src/ameba/rule/style/large_numbers.cr
+++ b/src/ameba/rule/style/large_numbers.cr
@@ -42,7 +42,13 @@ module Ameba::Rule::Style
         parsed = parse_number token.raw
 
         if allowed?(*parsed) && (expected = underscored *parsed) != token.raw
-          issue_for token, MSG % expected
+          location = token.location
+          end_location = Crystal::Location.new(
+            location.filename,
+            location.line_number,
+            location.column_number + token.raw.size - 1
+          )
+          issue_for location, end_location, MSG % expected
         end
       end
     end

--- a/src/ameba/spec/expect_issue.cr
+++ b/src/ameba/spec/expect_issue.cr
@@ -53,8 +53,10 @@ module Ameba::Spec::ExpectIssue
                    normalize = true,
                    *,
                    file = __FILE__,
-                   line = __LINE__)
+                   line = __LINE__,
+                   **replacements)
     annotated_code = normalize_code(annotated_code) if normalize
+    annotated_code = format_issue(annotated_code, **replacements)
     expected_annotations = AnnotatedSource.parse(annotated_code)
     lines = expected_annotations.lines
     code = lines.join('\n')
@@ -104,5 +106,15 @@ module Ameba::Spec::ExpectIssue
       rules.catch(source)
     end
     AnnotatedSource.new(lines, source.issues)
+  end
+
+  private def format_issue(code, **replacements)
+    replacements.each do |keyword, value|
+      value = value.to_s
+      code = code.gsub("%{#{keyword}}", value)
+      code = code.gsub("^{#{keyword}}", "^" * value.size)
+      code = code.gsub("_{#{keyword}}", " " * value.size)
+    end
+    code
   end
 end


### PR DESCRIPTION
This allows `%{keyword}` to be replaced with `keyword.to_s`, `^{keyword}` with carets, and `_{keyword}` with spaces. This is done by passing in a named parameter to `expect_issue` like so:

```crystal
expect_issue rule, <<-CRYSTAL, number: number
  number = %{number}
         # ^{number} error: Large numbers should be written with underscores: #{expected}
  CRYSTAL
```

When `number` is `123456_f32`, this becomes:

```
  number = 123456_f32
         # ^^^^^^^^^^ error: Large numbers should be written with underscores: 123_456_f32
```