### PR TITLE
Set src files as Makefile prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ PREFIX ?= /usr/local
 SHARD_BIN ?= ../../bin
 SRC_FILES = $(shell find src/ -type f)
 
+.PHONY: build clean install bin run_file test
+
 build: bin/ameba
 bin/ameba: $(SRC_FILES)
 	$(SHARDS_BIN) build $(CRFLAGS)


### PR DESCRIPTION
This will cause `make build` to compile a new binary whenever a `src` file is edited. This way, one does not need to run `make clean` before running `make` again.