### PR TITLE
Refactor `AST::ImplicitReturnVisitor` by removing the `node_is_used` argument passed to the underlying rule

### DIFF
--- a/src/ameba/rule/lint/unused_comparison.cr
+++ b/src/ameba/rule/lint/unused_comparison.cr
@@ -48,8 +48,8 @@ module Ameba::Rule::Lint
       AST::ImplicitReturnVisitor.new(self, source)
     end
 
-    def test(source, node : Crystal::Call, node_is_used : Bool)
-      if !node_is_used && node.name.in?(COMPARISON_OPERATORS) && node.args.size == 1
+    def test(source, node : Crystal::Call)
+      if node.name.in?(COMPARISON_OPERATORS) && node.args.size == 1
         issue_for node, MSG
       end
     end

--- a/src/ameba/rule/lint/unused_generic_or_union.cr
+++ b/src/ameba/rule/lint/unused_generic_or_union.cr
@@ -47,14 +47,12 @@ module Ameba::Rule::Lint
       AST::ImplicitReturnVisitor.new(self, source)
     end
 
-    def test(source, node : Crystal::Call, node_is_used : Bool)
-      return if node_is_used || !path_or_generic_union?(node)
-
-      issue_for node, MSG_UNION
+    def test(source, node : Crystal::Call)
+      issue_for node, MSG_UNION if path_or_generic_union?(node)
     end
 
-    def test(source, node : Crystal::Generic, node_is_used : Bool)
-      issue_for node, MSG_GENERIC unless node_is_used
+    def test(source, node : Crystal::Generic)
+      issue_for node, MSG_GENERIC
     end
 
     private def path_or_generic_union?(node : Crystal::Call) : Bool

--- a/src/ameba/rule/lint/unused_literal.cr
+++ b/src/ameba/rule/lint/unused_literal.cr
@@ -55,10 +55,10 @@ module Ameba::Rule::Lint
       AST::ImplicitReturnVisitor.new(self, source)
     end
 
-    def test(source, node : Crystal::RegexLiteral, node_is_used : Bool)
+    def test(source, node : Crystal::RegexLiteral)
       # Locations for Regex literals were added in Crystal v1.15.0
       {% if compare_versions(Crystal::VERSION, "1.15.0") >= 0 %}
-        issue_for node, MSG unless node_is_used
+        issue_for node, MSG
       {% end %}
     end
 
@@ -69,9 +69,8 @@ module Ameba::Rule::Lint
              Crystal::TupleLiteral | Crystal::NumberLiteral |
              Crystal::StringLiteral | Crystal::SymbolLiteral |
              Crystal::NamedTupleLiteral | Crystal::StringInterpolation,
-      node_is_used : Bool,
     )
-      issue_for node, MSG unless node_is_used
+      issue_for node, MSG
     end
   end
 end


### PR DESCRIPTION
This cleans up the rule consumers' code and avoid redundant conditions.

/cc @nobodywasishere 