### PR TITLE
Fix Git SHA command for windows

### DIFF
--- a/src/ameba/version.cr
+++ b/src/ameba/version.cr
@@ -1,7 +1,7 @@
 module Ameba
   VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
   {% if flag?(:windows) %}
-    GIT_SHA = {{ `git rev-parse --short HEAD`.chomp.stringify }}.presence
+    GIT_SHA = nil
   {% else %}
     GIT_SHA = {{ `(git rev-parse --short HEAD || true) 2>/dev/null`.chomp.stringify }}.presence
   {% end %}


### PR DESCRIPTION
This PR fixes the issue #666 

After the given changes, while the user is in a git repo (check problem no.2), ameba compile successfully
<img width="529" height="342" alt="image" src="https://github.com/user-attachments/assets/e5a5ad2c-4011-4af6-bd97-91fc9d288de8" />


## Added:

* Simple conditional compilation for windows for the `GIT_SHA` variable

## Problems

* The command doesn't redirect to `nul` with `2> nul` because I haven't found a way for it to work, it was returning error 128.
* The command can fail if the user is not in a git repo (not using the `|| cd .`, which is similar to the bash `|| true` for the same reason as the above one)