### PR TITLE
Remove trailing dot from issue messages

### DIFF
--- a/spec/ameba/rule/lint/unused_block_argument_spec.cr
+++ b/spec/ameba/rule/lint/unused_block_argument_spec.cr
@@ -51,7 +51,7 @@ module Ameba::Rule::Lint
     it "reports if unused and there is yield" do
       source = expect_issue subject, <<-CRYSTAL
         def method(a, b, c, &block)
-                           # ^^^^^ error: Use `&` as an argument name to indicate that it won't be referenced.
+                           # ^^^^^ error: Use `&` as an argument name to indicate that it won't be referenced
           3.times do |i|
             i.try do
               yield i

--- a/spec/ameba/rule/performance/minmax_after_map_spec.cr
+++ b/spec/ameba/rule/performance/minmax_after_map_spec.cr
@@ -14,11 +14,11 @@ module Ameba::Rule::Performance
     it "reports if there is a `min/max/minmax` call followed by `map`" do
       source = expect_issue subject, <<-CRYSTAL
         %w[Alice Bob].map { |name| name.size }.min
-                    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Use `min_of {...}` instead of `map {...}.min`.
+                    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Use `min_of {...}` instead of `map {...}.min`
         %w[Alice Bob].map(&.size).max.zero?
-                    # ^^^^^^^^^^^^^^^ error: Use `max_of {...}` instead of `map {...}.max`.
+                    # ^^^^^^^^^^^^^^^ error: Use `max_of {...}` instead of `map {...}.max`
         %w[Alice Bob].map(&.size).minmax?
-                    # ^^^^^^^^^^^^^^^^^^^ error: Use `minmax_of? {...}` instead of `map {...}.minmax?`.
+                    # ^^^^^^^^^^^^^^^^^^^ error: Use `minmax_of? {...}` instead of `map {...}.minmax?`
         CRYSTAL
 
       expect_correction source, <<-CRYSTAL

--- a/spec/ameba/rule/performance/size_after_filter_spec.cr
+++ b/spec/ameba/rule/performance/size_after_filter_spec.cr
@@ -19,7 +19,7 @@ module Ameba::Rule::Performance
     it "reports if there is a select followed by size" do
       expect_issue subject, <<-CRYSTAL
         [1, 2, 3].select { |e| e > 2 }.size
-                # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Use `count {...}` instead of `select {...}.size`.
+                # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Use `count {...}` instead of `select {...}.size`
         CRYSTAL
     end
 
@@ -32,14 +32,14 @@ module Ameba::Rule::Performance
     it "reports if there is a reject followed by size" do
       expect_issue subject, <<-CRYSTAL
         [1, 2, 3].reject { |e| e < 2 }.size
-                # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Use `count {...}` instead of `reject {...}.size`.
+                # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Use `count {...}` instead of `reject {...}.size`
         CRYSTAL
     end
 
     it "reports if a block shorthand used" do
       expect_issue subject, <<-CRYSTAL
         [1, 2, 3].reject(&.empty?).size
-                # ^^^^^^^^^^^^^^^^^^^^^ error: Use `count {...}` instead of `reject {...}.size`.
+                # ^^^^^^^^^^^^^^^^^^^^^ error: Use `count {...}` instead of `reject {...}.size`
         CRYSTAL
     end
 

--- a/spec/ameba/rule/style/guard_clause_spec.cr
+++ b/spec/ameba/rule/style/guard_clause_spec.cr
@@ -7,14 +7,14 @@ private def it_reports_body(body, *, file = __FILE__, line = __LINE__)
     source = expect_issue rule, <<-CRYSTAL, file: file, line: line
       def func
         if something
-      # ^^ error: Use a guard clause (`return unless something`) instead of wrapping the code inside a conditional expression.
+      # ^^ error: Use a guard clause (`return unless something`) instead of wrapping the code inside a conditional expression
           #{body}
         end
       end
 
       def func
         unless something
-      # ^^^^^^ error: Use a guard clause (`return if something`) instead of wrapping the code inside a conditional expression.
+      # ^^^^^^ error: Use a guard clause (`return if something`) instead of wrapping the code inside a conditional expression
           #{body}
         end
       end
@@ -40,7 +40,7 @@ private def it_reports_body(body, *, file = __FILE__, line = __LINE__)
       def func
         test
         if something
-      # ^^ error: Use a guard clause (`return unless something`) instead of wrapping the code inside a conditional expression.
+      # ^^ error: Use a guard clause (`return unless something`) instead of wrapping the code inside a conditional expression
           #{body}
         end
       end
@@ -48,7 +48,7 @@ private def it_reports_body(body, *, file = __FILE__, line = __LINE__)
       def func
         test
         unless something
-      # ^^^^^^ error: Use a guard clause (`return if something`) instead of wrapping the code inside a conditional expression.
+      # ^^^^^^ error: Use a guard clause (`return if something`) instead of wrapping the code inside a conditional expression
           #{body}
         end
       end
@@ -79,7 +79,7 @@ private def it_reports_control_expression(kw, *, file = __FILE__, line = __LINE_
     source = expect_issue rule, <<-CRYSTAL, file: file, line: line
       def func
         if something
-      # ^^ error: Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
+      # ^^ error: Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression
           #{kw}
         else
           puts "hello"
@@ -94,7 +94,7 @@ private def it_reports_control_expression(kw, *, file = __FILE__, line = __LINE_
     source = expect_issue rule, <<-CRYSTAL, file: file, line: line
       def func
         if something
-      # ^^ error: Use a guard clause (`#{kw} unless something`) instead of wrapping the code inside a conditional expression.
+      # ^^ error: Use a guard clause (`#{kw} unless something`) instead of wrapping the code inside a conditional expression
         puts "hello"
         else
           #{kw}
@@ -162,7 +162,7 @@ private def it_reports_control_expression(kw, *, file = __FILE__, line = __LINE_
     source = expect_issue rule, <<-CRYSTAL, file: file, line: line
       def func
         if something
-      # ^^ error: Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
+      # ^^ error: Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression
           #{kw}
         else
           puts "hello" \\
@@ -278,7 +278,7 @@ module Ameba::Rule::Style
       source = expect_issue subject, <<-CRYSTAL
         def func
           if something
-        # ^^ error: Use a guard clause (`work && return if something`) instead of wrapping the code inside a conditional expression.
+        # ^^ error: Use a guard clause (`work && return if something`) instead of [...]
             work && return
           else
             test
@@ -293,7 +293,7 @@ module Ameba::Rule::Style
       source = expect_issue subject, <<-CRYSTAL
         def func
           if something
-        # ^^ error: Use a guard clause (`test && return unless something`) instead of wrapping the code inside a conditional expression.
+        # ^^ error: Use a guard clause (`test && return unless something`) instead of [...]
             work
           else
             test && return
@@ -366,7 +366,7 @@ module Ameba::Rule::Style
           module CopTest
             def test
               if something
-            # ^^ error: Use a guard clause (`return unless something`) instead of wrapping the code inside a conditional expression.
+            # ^^ error: Use a guard clause (`return unless something`) instead of [...]
                 work
               end
             end

--- a/src/ameba/rule/base.cr
+++ b/src/ameba/rule/base.cr
@@ -13,7 +13,7 @@ module Ameba::Rule
   # class MyRule < Ameba::Rule::Base
   #   def test(source)
   #     if invalid?(source)
-  #       issue_for line, column, "Something wrong."
+  #       issue_for line, column, "Something wrong"
   #     end
   #   end
   #

--- a/src/ameba/rule/lint/unused_block_argument.cr
+++ b/src/ameba/rule/lint/unused_block_argument.cr
@@ -41,7 +41,7 @@ module Ameba::Rule::Lint
     MSG_UNUSED = "Unused block argument `%1$s`. If it's necessary, use `_%1$s` " \
                  "as an argument name to indicate that it won't be used."
 
-    MSG_YIELDED = "Use `&` as an argument name to indicate that it won't be referenced."
+    MSG_YIELDED = "Use `&` as an argument name to indicate that it won't be referenced"
 
     def test(source)
       AST::ScopeVisitor.new self, source

--- a/src/ameba/rule/performance/minmax_after_map.cr
+++ b/src/ameba/rule/performance/minmax_after_map.cr
@@ -33,7 +33,7 @@ module Ameba::Rule::Performance
       description "Identifies usage of `min/max/minmax` calls that follow `map`"
     end
 
-    MSG        = "Use `%s {...}` instead of `map {...}.%s`."
+    MSG        = "Use `%s {...}` instead of `map {...}.%s`"
     CALL_NAMES = %w[min min? max max? minmax minmax?]
 
     def test(source)

--- a/src/ameba/rule/performance/size_after_filter.cr
+++ b/src/ameba/rule/performance/size_after_filter.cr
@@ -41,7 +41,7 @@ module Ameba::Rule::Performance
       filter_names %w[select reject]
     end
 
-    MSG = "Use `count {...}` instead of `%s {...}.size`."
+    MSG = "Use `count {...}` instead of `%s {...}.size`"
 
     def test(source)
       AST::NodeVisitor.new self, source, skip: :macro

--- a/src/ameba/rule/style/guard_clause.cr
+++ b/src/ameba/rule/style/guard_clause.cr
@@ -61,7 +61,7 @@ module Ameba::Rule::Style
     end
 
     MSG = "Use a guard clause (`%s`) instead of wrapping the " \
-          "code inside a conditional expression."
+          "code inside a conditional expression"
 
     def test(source)
       AST::NodeVisitor.new self, source, skip: [


### PR DESCRIPTION
Several rules had a trailing dot included in the issue message, which is generally not used.