### PR TITLE
Add `Performance/TimesMap` rule

### DIFF
--- a/spec/ameba/rule/performance/times_map_spec.cr
+++ b/spec/ameba/rule/performance/times_map_spec.cr
@@ -1,0 +1,53 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Performance
+  describe TimesMap do
+    subject = TimesMap.new
+
+    it "passes if there is no potential performance improvements" do
+      expect_no_issues subject, <<-CRYSTAL
+        3.times.map { |i| i * i }.to_a { |i| i * -1 }
+        3.times.map { |i| i * i }
+        3.times { |i| i * i }
+        CRYSTAL
+    end
+
+    it "reports if there is map followed by flatten call" do
+      source = expect_issue subject, <<-CRYSTAL
+        foo.bar.times.map do |i|
+        # ^^^^^^^^^^^^^^^^^^^^^^ error: Use `Array.new(foo.bar) {...}` instead of `foo.bar.times.map {...}.to_a`
+          i * i
+        end.to_a
+        3.times.map { |i| i * i }.to_a
+        # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Use `Array.new(3) {...}` instead of `3.times.map {...}.to_a`
+        3.times.map(&block).to_a
+        # ^^^^^^^^^^^^^^^^^^^^^^ error: Use `Array.new(3) {...}` instead of `3.times.map {...}.to_a`
+        3.times.map(&block).to_a.select(&.odd?)
+        # ^^^^^^^^^^^^^^^^^^^^^^ error: Use `Array.new(3) {...}` instead of `3.times.map {...}.to_a`
+        CRYSTAL
+
+      expect_correction source, <<-CRYSTAL
+        Array.new(foo.bar) do |i|
+          i * i
+        end
+        Array.new(3) do |i| i * i end
+        Array.new(3, &block)
+        Array.new(3, &block).select(&.odd?)
+        CRYSTAL
+    end
+
+    it "does not report is source is a spec" do
+      expect_no_issues subject, path: "source_spec.cr", code: <<-CRYSTAL
+        3.times.map { |i| i * i }.to_a
+        CRYSTAL
+    end
+
+    context "macro" do
+      it "doesn't report in macro scope" do
+        expect_no_issues subject, <<-CRYSTAL
+          {{ 3.times.map { |i| i * i }.to_a }}
+          CRYSTAL
+      end
+    end
+  end
+end

--- a/src/ameba/rule/performance/times_map.cr
+++ b/src/ameba/rule/performance/times_map.cr
@@ -1,0 +1,66 @@
+require "./base"
+
+module Ameba::Rule::Performance
+  # This rule is used to identify usage of `times.map { ... }.to_a` calls.
+  #
+  # For example, this is considered invalid:
+  #
+  # ```
+  # 5.times.map { |i| i * 2 }.to_a
+  # ```
+  #
+  # And it should be written as this:
+  #
+  # ```
+  # Array.new(5) { |i| i * 2 }
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Performance/TimesMap:
+  #   Enabled: true
+  # ```
+  class TimesMap < Base
+    include AST::Util
+
+    properties do
+      since_version "1.7.0"
+      description "Identifies usage of `times.map { ... }.to_a` calls"
+    end
+
+    MSG = "Use `Array.new(%1$s) {...}` instead of `%1$s.times.map {...}.to_a`"
+
+    def test(source)
+      AST::NodeVisitor.new self, source, skip: :macro
+    end
+
+    # ameba:disable Metrics/CyclomaticComplexity
+    def test(source, node : Crystal::Call)
+      return if has_block?(node)
+      return unless node.name == "to_a" && (obj = node.obj)
+
+      return unless obj.is_a?(Crystal::Call) && has_block?(obj)
+      return unless obj.name == "map" && (obj2 = obj.obj)
+
+      return if !obj2.is_a?(Crystal::Call) || has_block?(obj2)
+      return unless obj2.name == "times" && (obj3 = obj2.obj)
+
+      return unless location = obj3.location
+      return unless end_location = name_end_location(node)
+
+      issue_for location, end_location, MSG % obj3 do |corrector|
+        corrected_code =
+          case
+          when block = obj.block
+            "Array.new(%s) %s" % {obj3, block}
+          when block_arg = obj.block_arg
+            "Array.new(%s, &%s)" % {obj3, block_arg}
+          end
+        next unless corrected_code
+
+        corrector.replace(location, end_location, corrected_code)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #654

---

Brings improvement of ~5%.

```cr
require "benchmark"

Benchmark.ips do |x|
  x.report("X1") { Array.new(10_000) { |i| "foo-#{i}" } }
  x.report("X2") { 10_000.times.map { |i| "foo-#{i}" }.to_a }
end
```

```
X1   1.97k (507.79µs) (± 2.01%)  1.75MB/op        fastest
X2   1.87k (535.46µs) (± 1.16%)  2.08MB/op   1.05× slower
```

`crystal --version`:

```
Crystal 1.18.2 (2025-10-21)

LLVM: 18.1.8
Default target: aarch64-apple-darwin21.6.0
```