### PR TITLE
Expand CLI glob args against project root directory

### DIFF
--- a/spec/ameba/cli/cmd_spec.cr
+++ b/spec/ameba/cli/cmd_spec.cr
@@ -223,7 +223,7 @@ module Ameba::CLI
         opts.globs.should eq Set{
           root.to_posix.to_s,
           Path[Dir.tempdir, "foo.cr"].to_posix.to_s,
-          Path[Dir.current, "**", "bar.cr"].to_posix.to_s,
+          Path[root, "**", "bar.cr"].to_posix.to_s,
         }
       end
 

--- a/src/ameba/cli/cmd.cr
+++ b/src/ameba/cli/cmd.cr
@@ -234,19 +234,21 @@ module Ameba::CLI
     end
     if globs.present?
       opts.globs = globs
-        .map! { |path| path_to_glob(path) }
+        .map! { |path| path_to_glob(path, root) }
         .to_set
     end
     if excluded.present?
       opts.excluded = excluded
-        .map! { |path| path_to_glob(path.lchop) }
+        .map! { |path| path_to_glob(path.lchop, root) }
         .to_set
     end
   end
 
-  private def path_to_glob(path : String) : String
+  private def path_to_glob(path : String, root = nil) : String
+    base = glob?(path) ? root || Dir.current : Dir.current
+
     Path[path]
-      .expand(home: true)
+      .expand(base, home: true)
       .to_posix
       .to_s
   end


### PR DESCRIPTION
```shell
ameba /path/to/project '!**/foo.cr'
```

**Before**: glob matches files in current directory (`pwd`)
**After**: glob matches files in project directory (`/path/to/project`)

Extracted from #713
Refs https://github.com/crystal-ameba/ameba/pull/713#discussion_r2598047156