### PR TITLE
Disable `Lint/Typos` rule by default

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,3 +1,4 @@
 Lint/Typos:
+  Enabled: true
   Excluded:
     - spec/ameba/rule/lint/typos_spec.cr

--- a/src/ameba/rule/lint/typos.cr
+++ b/src/ameba/rule/lint/typos.cr
@@ -17,6 +17,7 @@ module Ameba::Rule::Lint
     properties do
       since_version "1.6.0"
       description "Reports typos found in source files"
+      enabled false
 
       bin_path nil, as: String?
       fail_on_missing_bin false


### PR DESCRIPTION
ATM `Lint/Typos` rule has several important shortcomings:

- it uses global mutex, which slows down the execution **a lot**
- it loads each file into memory in order to pass it to the `typos` cli
- it needs its own file exclusion list
- it catches typos only in the source files, unlike `typos` cli or GH action

Refs #684