### PR TITLE
Normalize relative source paths by stripping the `./` prefix

### DIFF
--- a/src/ameba/glob_utils.cr
+++ b/src/ameba/glob_utils.cr
@@ -30,7 +30,9 @@ module Ameba
             glob = glob / "**" / "*.{cr,ecr}"
           end
 
-          Dir[glob.to_s]
+          glob = glob.to_s.lchop("./")
+
+          Dir[glob]
         end
         .uniq!
         .select! { |path| File.file?(path) }


### PR DESCRIPTION
**Before**: running `ameba` and `ameba .` results in different relative source paths: `foo.cr` vs `./foo.cr`
**After**: running `ameba` and `ameba .` results in the same relative source paths: `foo.cr` 