### PR TITLE
Skip auto compilation (drops `postinstall` script)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $ CRYSTAL_WORKERS=8 ameba #=> 10.14 seconds
 
 ## Installation
 
-### As a project dependency:
+### As a project dependency
 
 Add this to your application's `shard.yml`:
 
@@ -120,7 +120,35 @@ development_dependencies:
     github: crystal-ameba/ameba
 ```
 
-Build `bin/ameba` binary within your project directory while running `shards install`.
+To prioritize runtime performance over compilation time, you can add `ameba`
+target to the `shard.yml` file:
+
+```yaml
+targets:
+  ameba:
+    main: bin/ameba.cr
+```
+
+And then run:
+
+```sh
+$ shards build ameba -Dpreview_mt
+```
+
+Alternatively, skip adding `ameba` target and use `crystal build` command directly:
+
+```sh
+$ crystal build -Dpreview_mt -o bin/ameba bin/ameba.cr
+```
+
+Both of these will result in a compiled binary placed under `bin/ameba` path.
+
+You can also just run the `bin/ameba.cr` file, compiling it on the fly,
+which is the slowest option:
+
+```sh
+$ bin/ameba.cr
+```
 
 ### OS X
 

--- a/bin/ameba.cr
+++ b/bin/ameba.cr
@@ -1,9 +1,9 @@
 #!/usr/bin/env crystal
 
-# Require ameba cli which starts the inspection.
-require "ameba/cli"
-
 # Require ameba extensions here which are added as project dependencies.
 # Example:
 #
 # require "ameba-performance"
+
+# Require ameba cli which starts the inspection.
+require "ameba/cli"

--- a/bin/ameba.cr
+++ b/bin/ameba.cr
@@ -1,3 +1,5 @@
+#!/usr/bin/env crystal
+
 # Require ameba cli which starts the inspection.
 require "ameba/cli"
 

--- a/shard.yml
+++ b/shard.yml
@@ -11,12 +11,7 @@ targets:
   json-schema-builder:
     main: src/json-schema-builder.cr
 
-scripts:
-  postinstall: shards build ameba -Dpreview_mt
-
-# TODO: remove pre-compiled executable in future releases
 executables:
-  - ameba
   - ameba.cr
 
 crystal: ~> 1.17


### PR DESCRIPTION
Small change with profound consequences 🚀 

- Ameba binary under `bin/ameba` stops being built by default, i.e., via `shards install/update`
- Main entry point for ameba is now `bin/ameba.cr` (which is also runnable)

> [!TIP]
> [VS Code Ameba Extension](https://github.com/crystal-ameba/vscode-crystal-ameba) will continue to use local ameba installation as long as it's compiled and available under `bin/ameba`

## Migration Guide

### Local

Add `ameba` target to the `shard.yml` file:

```yaml
targets:
  ameba:
    main: bin/ameba.cr
```

And then run:

```sh
$ shards build ameba -Dpreview_mt
```

Or, skip adding a new `ameba` target and run:

```sh
$ crystal build -Dpreview_mt -o bin/ameba bin/ameba.cr
```

### CI

> [!NOTE]
> Using the [Ameba GitHub Action](https://github.com/crystal-ameba/github-action) is a preferred alternative due to its precompiled binary usage.
> Typical workflow run is ~10 seconds _vs_ ~1+ minute for `bin/ameba`.

- Remove step running `bin/ameba` within the main CI workflow
- Add a separate `ameba.yml` workflow file with contents (adapt to your needs):

```yaml
name: Ameba

on:
  push:
  pull_request:

permissions:
  contents: read

jobs:
  lint:
    runs-on: ubuntu-latest

    steps:
      - name: Download source
        uses: actions/checkout@v6

      - name: Run Ameba Linter
        uses: crystal-ameba/github-action@master
```

Or, if you want to run it as a part of your own workflow(s), change `on` to:

```yaml
on:
  workflow_call:
```

And then include it as a job in your workflow, like this:

```yaml
jobs:

  # ...

  ameba:
    uses: ./.github/workflows/ameba.yml
```

If, for some reason, you'd still want to build the ameba locally, add a step before running it:

```yaml
steps:

  # ...

  - name: Build Ameba Linter
    run: crystal build -Dpreview_mt -o bin/ameba bin/ameba.cr
```

Refs #470, #684