### PR TITLE
Fix `--fail-level` CLI switch not having any effect

### DIFF
--- a/src/ameba/runner.cr
+++ b/src/ameba/runner.cr
@@ -85,7 +85,10 @@ module Ameba
     end
 
     protected def rule_runnable?(rule, version)
-      rule.enabled? && !rule.special? && rule_satisfies_version?(rule, version)
+      rule.enabled? &&
+        !rule.special? &&
+        rule.severity <= @severity &&
+        rule_satisfies_version?(rule, version)
     end
 
     protected def rule_satisfies_version?(rule, version)
@@ -196,9 +199,7 @@ module Ameba
     # runner.success? # => true or false
     # ```
     def success?
-      @sources.all? &.issues.none? do |issue|
-        issue.enabled? && issue.rule.severity <= @severity
-      end
+      @sources.all? &.issues.none? &.enabled?
     end
 
     private MAX_ITERATIONS = 200


### PR DESCRIPTION
Found this while working on https://github.com/crystal-ameba/github-action/issues/24. This slipped through the cracks for a looong time (I guess since the beginning, i.e., 575fe07879a3c309dfca2fa26cea78ac1e1b0734 - released as a part of `v0.9.2`), not a popular switch it seems 😅

Refs #100