### PR TITLE
Add release workflow to build/upload on release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,19 +14,19 @@ jobs:
   draft:
     runs-on: ubuntu-latest
     steps:
-      - run: gh release -R ${{github.repository}} create ${{github.ref_name}} --draft --generate-notes
+      - run: gh release -R ${{ github.repository }} create ${{ github.ref_name }} --draft --generate-notes
 
   linux-musl:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - run: docker run --rm -v $PWD:/mnt -w /mnt crystallang/crystal:1-alpine shards build ameba --static -Dpreview_mt --release
-      - run: tar zcf ameba-${{github.ref_name}}-$(uname -m)-linux-musl.tar.gz -C bin ameba
-      - run: gh release -R ${{github.repository}} upload ${{github.ref_name}} ameba-${{github.ref_name}}-$(uname -m)-linux-musl.tar.gz
+      - run: tar zcf ameba-${{ github.ref_name }}-$(uname -m)-linux-musl.tar.gz -C bin ameba
+      - run: gh release -R ${{ github.repository }} upload ${{ github.ref_name }} ameba-${{ github.ref_name }}-$(uname -m)-linux-musl.tar.gz
 
   darwin:
     strategy:
@@ -35,13 +35,13 @@ jobs:
         include:
           - {os: macos-15, arch: aarch64}
           - {os: macos-15-intel, arch: x86_64}
-    runs-on: ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: crystal-lang/install-crystal@v1
       - uses: actions/checkout@v6
       - run: shards build ameba -Dpreview_mt --release
-      - run: tar zcf ameba-${{github.ref_name}}-${{matrix.arch}}-darwin.tar.gz -C bin ameba ameba.dwarf
-      - run: gh release -R ${{github.repository}} upload ${{github.ref_name}} ameba-${{github.ref_name}}-${{matrix.arch}}-darwin.tar.gz
+      - run: tar zcf ameba-${{ github.ref_name }}-${{ matrix.arch }}-darwin.tar.gz -C bin ameba ameba.dwarf
+      - run: gh release -R ${{ github.repository }} upload ${{ github.ref_name }} ameba-${{ github.ref_name }}-${{ matrix.arch }}-darwin.tar.gz
 
   x86_64-windows-msvc:
     runs-on: windows-2025
@@ -49,6 +49,6 @@ jobs:
       - uses: crystal-lang/install-crystal@v1
       - uses: actions/checkout@v6
       - run: shards build ameba --static -Dpreview_mt --release
-      - run: cd bin; 7z a ../ameba-${{github.ref_name}}-x86_64-windows-msvc.zip ameba.exe ameba.pdb
-      - run: gh release -R ${{github.repository}} upload ${{github.ref_name}} ameba-${{github.ref_name}}-x86_64-windows-msvc.zip
+      - run: cd bin; 7z a ../ameba-${{ github.ref_name }}-x86_64-windows-msvc.zip ameba.exe ameba.pdb
+      - run: gh release -R ${{ github.repository }} upload ${{ github.ref_name }} ameba-${{ github.ref_name }}-x86_64-windows-msvc.zip
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,11 @@ on:
     tags:
       - "v*.*.*"
 
-env:
-  GH_TOKEN: ${{ github.token }}
 permissions:
   contents: write
+
+env:
+  GH_TOKEN: ${{ github.token }}
 
 jobs:
   draft:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh release -R ${{github.repository}} create ${{github.ref_name}} --draft --generate-notes
+
+  linux-musl:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v6
+      - run: docker run --rm -v $PWD:/mnt -w /mnt crystallang/crystal:1-alpine shards build ameba --static -Dpreview_mt --release
+      - run: tar zcf ameba-${{github.ref_name}}-$(uname -m)-linux-musl.tar.gz -C bin ameba
+      - run: gh release -R ${{github.repository}} upload ${{github.ref_name}} ameba-${{github.ref_name}}-$(uname -m)-linux-musl.tar.gz
+
+  darwin:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {os: macos-15, arch: aarch64}
+          - {os: macos-15-intel, arch: x86_64}
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: crystal-lang/install-crystal@v1
+      - uses: actions/checkout@v6
+      - run: shards build ameba -Dpreview_mt --release
+      - run: tar zcf ameba-${{github.ref_name}}-${{matrix.arch}}-darwin.tar.gz -C bin ameba ameba.dwarf
+      - run: gh release -R ${{github.repository}} upload ${{github.ref_name}} ameba-${{github.ref_name}}-${{matrix.arch}}-darwin.tar.gz
+
+  x86_64-windows-msvc:
+    runs-on: windows-2025
+    steps:
+      - uses: crystal-lang/install-crystal@v1
+      - uses: actions/checkout@v6
+      - run: shards build ameba --static -Dpreview_mt --release
+      - run: cd bin; 7z a ../ameba-${{github.ref_name}}-x86_64-windows-msvc.zip ameba.exe ameba.pdb
+      - run: gh release -R ${{github.repository}} upload ${{github.ref_name}} ameba-${{github.ref_name}}-x86_64-windows-msvc.zip
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   GH_TOKEN: ${{ github.token }}
+permissions:
+  contents: write
 
 jobs:
   draft:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      - run: docker run --rm -v $PWD:/mnt -w /mnt crystallang/crystal:1-alpine shards build ameba --static -Dpreview_mt --release
+      - run: docker run --rm -v $PWD:/mnt -w /mnt crystallang/crystal:latest-alpine shards build ameba --static -Dpreview_mt --release
       - run: tar zcf ameba-${{ github.ref_name }}-$(uname -m)-linux-musl.tar.gz -C bin ameba
       - run: gh release -R ${{ github.repository }} upload ${{ github.ref_name }} ameba-${{ github.ref_name }}-$(uname -m)-linux-musl.tar.gz
 


### PR DESCRIPTION
Introduces a new workflow to draft a release, build Ameba for the major targets, and upload the assets to the release whenever a version tag is created.

Why?

1. I'm always surprised that Ameba doesn't distribute prebuilt binaries.
2. #470 and https://github.com/crystal-ameba/ameba/pull/653#issuecomment-3942125040
3. I was wondering how complex it would be to automate building crystal applications across the main systems (Linux, macOS, Windows) and architectures (aarch64, x86_64).

Turns out, it was kinda straightforward. Ameba doesn't have external dependencies outside of those already from stdlib (gc, pcre2, yaml), and we distribute Crystal tarballs for all the above targets. It still required a few tricks, though:

- **Linux**: use docker to statically compile against musl-libc for a portable executable;
- **macOS**: can't build static executable, but luckily the external libs get statically linked by default (otherwise we'd have to cross compile, then link manually);
- **Windows**: build a static executable so we don't have to copy the DLL files.

You can see example (fake) releases in my fork:
https://github.com/ysbaddaden/ameba/releases

And their associated build processes:
- https://github.com/ysbaddaden/ameba/actions/runs/22523555147
- https://github.com/ysbaddaden/ameba/actions/runs/22523222820

NOTE: it doesn't invalidate #653 though this workflow is a bit simpler and with support for more platforms: linux (x86, arm), mac (x86, arm) and windows (x86).

References #470, #653.