### PR TITLE
Don’t install `bin/ameba.cr` executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ target to the `shard.yml` file:
 ```yaml
 targets:
   ameba:
-    main: bin/ameba.cr
+    main: lib/ameba/bin/ameba.cr
 ```
 
 And then run:
@@ -138,16 +138,16 @@ $ shards build ameba -Dpreview_mt
 Alternatively, skip adding `ameba` target and use `crystal build` command directly:
 
 ```sh
-$ crystal build -Dpreview_mt -o bin/ameba bin/ameba.cr
+$ crystal build -Dpreview_mt -o bin/ameba lib/ameba/bin/ameba.cr
 ```
 
 Both of these will result in a compiled binary placed under `bin/ameba` path.
 
-You can also just run the `bin/ameba.cr` file, compiling it on the fly,
+You can also just run the `lib/ameba/bin/ameba.cr` file, compiling it on the fly,
 which is the slowest option:
 
 ```sh
-$ bin/ameba.cr
+$ lib/ameba/bin/ameba.cr
 ```
 
 ### OS X

--- a/shard.yml
+++ b/shard.yml
@@ -11,9 +11,6 @@ targets:
   json-schema-builder:
     main: src/json-schema-builder.cr
 
-executables:
-  - ameba.cr
-
 crystal: ~> 1.19
 
 license: MIT


### PR DESCRIPTION
This file gets overridden on every successful `shards install/update` call, which pretty much defeats its whole purpose - i.e., being able to customize your local ameba installation.

Instead, it's better to use the `lib/ameba/bin/ameba.cr` which already comes with the Ameba dependency, or just to copy it over to the `bin` directory for local modification—if necessary.

Refs #470