### PR TITLE
Fix edgecase in `Formatter::Util#affected_code` location marker display logic

### DIFF
--- a/spec/ameba/formatter/util_spec.cr
+++ b/spec/ameba/formatter/util_spec.cr
@@ -145,6 +145,40 @@ module Ameba::Formatter
           .should eq "> a = 1\n  ^\n"
       end
 
+      context "trimming" do
+        max_length = 33
+
+        code = <<-CRYSTAL
+          FOO = "#{"foo" * 111}"
+          CRYSTAL
+
+        it "trims the affected line to `max_length` if location is within the trimmed line" do
+          location = Crystal::Location.new("filename", 1, max_length - 10)
+          end_location = Crystal::Location.new("filename", 1, max_length + 10)
+
+          affected_code = subject.affected_code(code, location, end_location, max_length: max_length)
+          affected_code = subject.deansify(affected_code).should_not be_nil
+
+          affected_code.should start_with "> %s\n" % subject.trim(code, max_length)
+          affected_code.should end_with "^%s^\n" % {
+            "-" * (max_length - location.column_number - 1),
+          }
+        end
+
+        it "does not trim the affected line if location is not within the `max_length`" do
+          location = Crystal::Location.new("filename", 1, max_length + 10)
+          end_location = Crystal::Location.new("filename", 1, max_length + 30)
+
+          affected_code = subject.affected_code(code, location, end_location, max_length: max_length)
+          affected_code = subject.deansify(affected_code).should_not be_nil
+
+          affected_code.should start_with "> %s\n" % code
+          affected_code.should end_with "^%s^\n" % {
+            "-" * (end_location.column_number - location.column_number - 1),
+          }
+        end
+      end
+
       it "returns correct line if it is found" do
         code = <<-CRYSTAL
           a = 1
@@ -154,7 +188,7 @@ module Ameba::Formatter
           .should eq "> a = 1\n  ^\n"
       end
 
-      it "returns correct line if it is found" do
+      it "returns correct line if it is found (2)" do
         code = <<-CRYSTAL
           # pre:1
             # pre:2

--- a/src/ameba/formatter/util.cr
+++ b/src/ameba/formatter/util.cr
@@ -158,6 +158,10 @@ module Ameba::Formatter
           end_column = end_location.column_number
 
           if end_lineno == lineno && end_column > column
+            if column < max_length
+              end_column = {end_column, max_length}.min
+            end
+
             length = end_column - column
             length -= 1
 

--- a/src/ameba/formatter/util.cr
+++ b/src/ameba/formatter/util.cr
@@ -158,10 +158,10 @@ module Ameba::Formatter
           end_column = end_location.column_number
 
           if end_lineno == lineno && end_column > column
-            end_position = end_column - column
-            end_position -= 1
+            length = end_column - column
+            length -= 1
 
-            str << ("-" * end_position).colorize(:dark_gray)
+            str << ("-" * length).colorize(:dark_gray)
             str << "^".colorize(:yellow)
           end
         end


### PR DESCRIPTION
Before:

```sh
spec/models/activity_pub/object_spec.cr:1935:102
[W] Lint/NonExistentRule: Such rules do not exist: `Ktistec/NoImperativeFactories`
> Factory.create(:actor, iri: "https://test.test/actors/#{('a'.ord + i).chr}") # ameba:disable Ktistec/NoImper ...
                                                                                               ^---------------------------^
```

After:

```sh
spec/models/activity_pub/object_spec.cr:1935:102
[W] Lint/NonExistentRule: Such rules do not exist: `Ktistec/NoImperativeFactories`
> Factory.create(:actor, iri: "https://test.test/actors/#{('a'.ord + i).chr}") # ameba:disable Ktistec/NoImper ...
                                                                                               ^-----------------^
```