### PR TITLE
Change `Lint::NonExistentRule#since_version` to `0.13.0`

### DIFF
--- a/src/ameba/rule/lint/non_existent_rule.cr
+++ b/src/ameba/rule/lint/non_existent_rule.cr
@@ -21,7 +21,7 @@ module Ameba::Rule::Lint
     include AST::Util
 
     properties do
-      since_version "1.7.0"
+      since_version "0.13.0"
       description "Reports non-existent rules in comment directives"
     end
 


### PR DESCRIPTION
I believe that's more sensible, since this rule was originally introduced in version `0.13.0` as a part of the `Lint/BadDirective` rule.

Followup to #809