### PR TITLE
fix: do not flag block argument shadowing across mutually exclusive branches in `Lint/ShadowingOuterLocalVar`

### DIFF
--- a/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
+++ b/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
@@ -194,13 +194,12 @@ module Ameba::Rule::Lint
         CRYSTAL
     end
 
+    # https://github.com/crystal-ameba/ameba/issues/819
     context "mutually exclusive branches" do
-      # https://github.com/crystal-ameba/ameba/issues/819
       it "does not report when assignment and block argument live in opposite if/else branches" do
         expect_no_issues subject, <<-CRYSTAL
           if rand > 0.5
             x = 1
-            puts x
           else
             [1, 2].each { |x| puts x }
           end
@@ -211,7 +210,6 @@ module Ameba::Rule::Lint
         expect_no_issues subject, <<-CRYSTAL
           if a
             x = 1
-            puts x
           elsif b
             [1, 2].each { |x| puts x }
           end
@@ -222,7 +220,6 @@ module Ameba::Rule::Lint
         expect_no_issues subject, <<-CRYSTAL
           unless cond
             x = 1
-            puts x
           else
             [1, 2].each { |x| puts x }
           end
@@ -234,7 +231,6 @@ module Ameba::Rule::Lint
           case value
           when 1
             x = 1
-            puts x
           when 2
             [1, 2].each { |x| puts x }
           end
@@ -246,7 +242,6 @@ module Ameba::Rule::Lint
           case value
           when 1
             x = 1
-            puts x
           else
             [1, 2].each { |x| puts x }
           end
@@ -258,7 +253,6 @@ module Ameba::Rule::Lint
           if outer
             if inner
               x = 1
-              puts x
             else
               [1, 2].each { |x| puts x }
             end
@@ -292,7 +286,7 @@ module Ameba::Rule::Lint
 
       it "reports when assignment is in if-condition (runs regardless of branch)" do
         expect_issue subject, <<-CRYSTAL
-          if (x = compute)
+          if x = compute
             puts x
           else
             [1, 2].each do |x|
@@ -308,7 +302,6 @@ module Ameba::Rule::Lint
           x = 1
           if cond
             x = 2
-            puts x
           else
             [1, 2].each do |x|
                           # ^ error: Shadowing outer local variable `x`
@@ -324,7 +317,6 @@ module Ameba::Rule::Lint
             raise "x"
           rescue ArgumentError
             x = 1
-            puts x
           rescue
             [1, 2].each { |x| puts x }
           end
@@ -337,7 +329,6 @@ module Ameba::Rule::Lint
             raise "x"
           rescue
             x = 1
-            puts x
           else
             [1, 2].each { |x| puts x }
           end
@@ -348,7 +339,6 @@ module Ameba::Rule::Lint
         expect_issue subject, <<-CRYSTAL
           begin
             x = 1
-            puts x
           rescue
             [1, 2].each do |x|
                           # ^ error: Shadowing outer local variable `x`
@@ -363,7 +353,6 @@ module Ameba::Rule::Lint
           select
           when v = ch1.receive
             x = v
-            puts x
           when ch2.receive
             [1, 2].each { |x| puts x }
           end
@@ -374,7 +363,6 @@ module Ameba::Rule::Lint
         expect_no_issues subject, <<-CRYSTAL
           if rand > 0.5
             x = 1
-            puts x
           else
             -> (x : Int32) { x + 1 }
           end

--- a/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
+++ b/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
@@ -194,6 +194,194 @@ module Ameba::Rule::Lint
         CRYSTAL
     end
 
+    context "mutually exclusive branches" do
+      # https://github.com/crystal-ameba/ameba/issues/819
+      it "does not report when assignment and block argument live in opposite if/else branches" do
+        expect_no_issues subject, <<-CRYSTAL
+          if rand > 0.5
+            x = 1
+            puts x
+          else
+            [1, 2].each { |x| puts x }
+          end
+          CRYSTAL
+      end
+
+      it "does not report when assignment is in if-then and block is in elsif" do
+        expect_no_issues subject, <<-CRYSTAL
+          if a
+            x = 1
+            puts x
+          elsif b
+            [1, 2].each { |x| puts x }
+          end
+          CRYSTAL
+      end
+
+      it "does not report when assignment and block are in different unless branches" do
+        expect_no_issues subject, <<-CRYSTAL
+          unless cond
+            x = 1
+            puts x
+          else
+            [1, 2].each { |x| puts x }
+          end
+          CRYSTAL
+      end
+
+      it "does not report when assignment and block are in different case whens" do
+        expect_no_issues subject, <<-CRYSTAL
+          case value
+          when 1
+            x = 1
+            puts x
+          when 2
+            [1, 2].each { |x| puts x }
+          end
+          CRYSTAL
+      end
+
+      it "does not report when assignment is in case-when and block is in case-else" do
+        expect_no_issues subject, <<-CRYSTAL
+          case value
+          when 1
+            x = 1
+            puts x
+          else
+            [1, 2].each { |x| puts x }
+          end
+          CRYSTAL
+      end
+
+      it "does not report when branches are nested and still mutually exclusive" do
+        expect_no_issues subject, <<-CRYSTAL
+          if outer
+            if inner
+              x = 1
+              puts x
+            else
+              [1, 2].each { |x| puts x }
+            end
+          end
+          CRYSTAL
+      end
+
+      it "reports when assignment dominates the block (no mutual exclusion)" do
+        expect_issue subject, <<-CRYSTAL
+          x = 1
+          if cond
+            [1, 2].each do |x|
+                          # ^ error: Shadowing outer local variable `x`
+              puts x
+            end
+          end
+          CRYSTAL
+      end
+
+      it "reports when assignment is in same branch as block" do
+        expect_issue subject, <<-CRYSTAL
+          if cond
+            x = 1
+            [1, 2].each do |x|
+                          # ^ error: Shadowing outer local variable `x`
+              puts x
+            end
+          end
+          CRYSTAL
+      end
+
+      it "reports when assignment is in if-condition (runs regardless of branch)" do
+        expect_issue subject, <<-CRYSTAL
+          if (x = compute)
+            puts x
+          else
+            [1, 2].each do |x|
+                          # ^ error: Shadowing outer local variable `x`
+              puts x
+            end
+          end
+          CRYSTAL
+      end
+
+      it "reports when any assignment can reach the block argument" do
+        expect_issue subject, <<-CRYSTAL
+          x = 1
+          if cond
+            x = 2
+            puts x
+          else
+            [1, 2].each do |x|
+                          # ^ error: Shadowing outer local variable `x`
+              puts x
+            end
+          end
+          CRYSTAL
+      end
+
+      it "does not report when assignment and block live in different rescue branches" do
+        expect_no_issues subject, <<-CRYSTAL
+          begin
+            raise "x"
+          rescue ArgumentError
+            x = 1
+            puts x
+          rescue
+            [1, 2].each { |x| puts x }
+          end
+          CRYSTAL
+      end
+
+      it "does not report when assignment is in a rescue and block is in the else branch" do
+        expect_no_issues subject, <<-CRYSTAL
+          begin
+            raise "x"
+          rescue
+            x = 1
+            puts x
+          else
+            [1, 2].each { |x| puts x }
+          end
+          CRYSTAL
+      end
+
+      it "reports when assignment in body can reach a rescue's block argument" do
+        expect_issue subject, <<-CRYSTAL
+          begin
+            x = 1
+            puts x
+          rescue
+            [1, 2].each do |x|
+                          # ^ error: Shadowing outer local variable `x`
+              puts x
+            end
+          end
+          CRYSTAL
+      end
+
+      it "does not report when assignment and block live in different select whens" do
+        expect_no_issues subject, <<-CRYSTAL
+          select
+          when v = ch1.receive
+            x = v
+            puts x
+          when ch2.receive
+            [1, 2].each { |x| puts x }
+          end
+          CRYSTAL
+      end
+
+      it "does not report when proc argument is in a mutually exclusive branch" do
+        expect_no_issues subject, <<-CRYSTAL
+          if rand > 0.5
+            x = 1
+            puts x
+          else
+            -> (x : Int32) { x + 1 }
+          end
+          CRYSTAL
+      end
+    end
+
     context "macro" do
       it "does not report shadowed vars in outer scope" do
         expect_no_issues subject, <<-CRYSTAL

--- a/src/ameba/rule/lint/shadowing_outer_local_var.cr
+++ b/src/ameba/rule/lint/shadowing_outer_local_var.cr
@@ -92,7 +92,7 @@ module Ameba::Rule::Lint
         ancestor2, branch2 = path2[i]
 
         return false unless ancestor1.same?(ancestor2)
-        return true if branch1 != branch2
+        return true unless branch1 == branch2
       end
 
       false
@@ -119,11 +119,7 @@ module Ameba::Rule::Lint
         true
       end
 
-      def visit(node : Crystal::If)
-        visit_conditional(node, node.cond, node.then, node.else)
-      end
-
-      def visit(node : Crystal::Unless)
+      def visit(node : Crystal::If | Crystal::Unless)
         visit_conditional(node, node.cond, node.then, node.else)
       end
 

--- a/src/ameba/rule/lint/shadowing_outer_local_var.cr
+++ b/src/ameba/rule/lint/shadowing_outer_local_var.cr
@@ -53,6 +53,8 @@ module Ameba::Rule::Lint
     private def find_shadowing(source, scope)
       return unless outer_scope = scope.outer_scope
 
+      branch_visitors = {} of UInt64 => BranchPathVisitor
+
       each_argument_node(scope) do |arg|
         # TODO: handle unpacked variables from `Block#unpacks`
         next unless name = arg.name.presence
@@ -62,14 +64,120 @@ module Ameba::Rule::Lint
         next if variable.nil? || !variable.declared_before?(arg)
         next if outer_scope.assigns_ivar?(name)
         next if outer_scope.assigns_type_dec?(name)
+        next if mutually_exclusive_branches?(branch_visitors, variable, arg)
 
         issue_for arg.node, MSG % name, prefer_name_location: true
       end
     end
 
+    private def mutually_exclusive_branches?(visitors, variable, arg)
+      return false if variable.assignments.empty?
+
+      scope_node = variable.scope.node
+      visitor = visitors[scope_node.object_id] ||= BranchPathVisitor.new.tap do |v|
+        scope_node.accept(v)
+      end
+
+      arg_path = visitor.paths[arg.node.object_id]
+      variable.assignments.all? do |assignment|
+        diverges?(arg_path, visitor.paths[assignment.node.object_id])
+      end
+    end
+
+    private def diverges?(path1, path2)
+      shared_depth = {path1.size, path2.size}.min
+
+      shared_depth.times do |i|
+        ancestor1, branch1 = path1[i]
+        ancestor2, branch2 = path2[i]
+
+        return false unless ancestor1.same?(ancestor2)
+        return true if branch1 != branch2
+      end
+
+      false
+    end
+
     private def each_argument_node(scope, &)
       scope.arguments.each do |arg|
         yield arg unless arg.ignored?
+      end
+    end
+
+    private class BranchPathVisitor < Crystal::Visitor
+      alias Segment = Tuple(Crystal::ASTNode, Symbol | Int32)
+      alias Path = Array(Segment)
+
+      getter paths = {} of UInt64 => Path
+
+      def initialize
+        @stack = Path.new
+      end
+
+      def visit(node : Crystal::ASTNode)
+        record(node)
+        true
+      end
+
+      def visit(node : Crystal::If)
+        visit_conditional(node, node.cond, node.then, node.else)
+      end
+
+      def visit(node : Crystal::Unless)
+        visit_conditional(node, node.cond, node.then, node.else)
+      end
+
+      def visit(node : Crystal::Case)
+        record(node)
+        node.cond.try &.accept(self)
+        visit_when_branches(node, node.whens, node.else)
+      end
+
+      def visit(node : Crystal::Select)
+        record(node)
+        visit_when_branches(node, node.whens, node.else)
+      end
+
+      def visit(node : Crystal::ExceptionHandler)
+        record(node)
+        node.body.accept(self)
+        node.rescues.try &.each_with_index do |rescue_node, index|
+          enter(node, index) { rescue_node.body.accept(self) }
+        end
+        if else_node = node.else
+          enter(node, :else) { else_node.accept(self) }
+        end
+        node.ensure.try &.accept(self)
+        false
+      end
+
+      private def visit_conditional(node, cond, then_branch, else_branch)
+        record(node)
+        cond.accept(self)
+        enter(node, :then) { then_branch.accept(self) }
+        enter(node, :else) { else_branch.accept(self) }
+        false
+      end
+
+      private def visit_when_branches(node, whens, else_node)
+        whens.each_with_index do |when_node, index|
+          when_node.conds.each &.accept(self)
+          enter(node, index) { when_node.body.accept(self) }
+        end
+        if else_node
+          enter(node, :else) { else_node.accept(self) }
+        end
+        false
+      end
+
+      private def enter(node, branch_id, &)
+        @stack.push({node, branch_id})
+        yield
+        @stack.pop
+      end
+
+      private def record(node)
+        paths[node.object_id] = @stack.dup
       end
     end
   end


### PR DESCRIPTION
Closes https://github.com/crystal-ameba/ameba/issues/819

Added a localized AST-walking check (`mutually_exclusive_branches?`) that records the branch path of the block argument and each assignment of the candidate variable. When every assignment diverges from the argument's path at a common branching ancestor, the outer assignment cannot reach the block argument and the warning is suppressed.

No `Branch` / `Branchable` infrastructure was reintroduced (recently removed in #795) — the check is contained in the rule.
