### PR TITLE
fix: do not flag block argument shadowing inside the initial assignment in `Lint/ShadowingOuterLocalVar`

### DIFF
--- a/spec/ameba/ast/variabling/variable_spec.cr
+++ b/spec/ameba/ast/variabling/variable_spec.cr
@@ -214,9 +214,23 @@ module Ameba::AST
         Variable.new(var1, scope).declared_before?(var2).should be_false
       end
 
-      it "is false is the node is the same var" do
+      it "is false if the node is the same var" do
         var = Crystal::Var.new("foo").at(Crystal::Location.new(nil, 2, 2))
         Variable.new(var, scope).declared_before?(var).should be_false
+      end
+
+      it "uses the first assignment's end location, not the target's location" do
+        target = Crystal::Var.new("x")
+        variable = Variable.new(target, scope)
+        assign = Crystal::Assign.new(target, Crystal::NilLiteral.new)
+          .at_end(Crystal::Location.new(nil, 1, 15))
+        variable.assignments << Assignment.new(assign, variable, scope)
+
+        inside_value = Crystal::Var.new("x").at(Crystal::Location.new(nil, 1, 12))
+        after_value = Crystal::Var.new("x").at(Crystal::Location.new(nil, 2, 1))
+
+        variable.declared_before?(inside_value).should be_false
+        variable.declared_before?(after_value).should be_true
       end
     end
   end

--- a/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
+++ b/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
@@ -194,6 +194,41 @@ module Ameba::Rule::Lint
         CRYSTAL
     end
 
+    context "block argument inside the introducing assignment" do
+      it "does not report when block argument shares a name with the outer assignment target" do
+        expect_no_issues subject, <<-CRYSTAL
+          x = foo { |x| x + 1 }
+          unit = units.find! { |unit| unit.name == name }
+          CRYSTAL
+      end
+
+      it "does not report when the block is nested inside the assignment value" do
+        expect_no_issues subject, <<-CRYSTAL
+          x = if cond
+                1
+              else
+                foo { |x| x + 1 }
+              end
+          CRYSTAL
+      end
+
+      it "reports when the outer variable is already declared before the assignment" do
+        expect_issue subject, <<-CRYSTAL
+          x = 1
+          x = foo { |x| x + 1 }
+                   # ^ error: Shadowing outer local variable `x`
+          CRYSTAL
+      end
+
+      it "reports when the outer variable is declared on a sibling statement" do
+        expect_issue subject, <<-CRYSTAL
+          x = 1
+          foo { |x| x + 1 }
+               # ^ error: Shadowing outer local variable `x`
+          CRYSTAL
+      end
+    end
+
     # https://github.com/crystal-ameba/ameba/issues/819
     context "mutually exclusive branches" do
       it "does not report when assignment and block argument live in opposite if/else branches" do

--- a/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
+++ b/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
@@ -198,7 +198,6 @@ module Ameba::Rule::Lint
       it "does not report when block argument shares a name with the outer assignment target" do
         expect_no_issues subject, <<-CRYSTAL
           x = foo { |x| x + 1 }
-          unit = units.find! { |unit| unit.name == name }
           CRYSTAL
       end
 

--- a/src/ameba/ast/variabling/variable.cr
+++ b/src/ameba/ast/variabling/variable.cr
@@ -136,14 +136,24 @@ module Ameba::AST
     end
 
     # Returns `true` if the variable is declared before the `node`.
+    #
+    # A local variable is considered declared once its first assignment
+    # finishes evaluating; a parameter is declared at the point it's
+    # introduced. This is distinct from the variable's lexical `location`:
+    # in `x = foo { |x| }` the outer `x` appears at column 1, but is only
+    # declared after the block runs.
     def declared_before?(node)
-      var_location, node_location = location, node.location
+      var_location, node_location = declaration_location, node.location
 
       return unless var_location && node_location
 
       (var_location.line_number < node_location.line_number) ||
         (var_location.line_number == node_location.line_number &&
           var_location.column_number < node_location.column_number)
+    end
+
+    private def declaration_location
+      assignments.first?.try(&.end_location) || location
     end
   end
 end


### PR DESCRIPTION
Closes #825
Relates to #144, https://github.com/crystal-ameba/ameba/commit/458c49273000a99798ac04acee50ef7755595935

