### PR TITLE
Raise on invalid file path

### DIFF
--- a/spec/ameba/cli/cmd_spec.cr
+++ b/spec/ameba/cli/cmd_spec.cr
@@ -7,8 +7,26 @@ module Ameba::CLI
   describe "Cmd" do
     describe ".run" do
       it "runs ameba" do
-        r = CLI.run %w[-f silent file.cr]
+        r = CLI.run ["-f", "silent", "--only", "Lint/ComparisonToBoolean", __FILE__]
         r.should be_true
+      end
+
+      it "raises when a non-existent file is provided" do
+        expect_raises(Exception, "No files found matching `not_there.cr`") do
+          CLI.run %w[-f silent not_there.cr]
+        end
+      end
+
+      it "raises when a glob matches no files" do
+        expect_raises(Exception, "No files found matching") do
+          CLI.run %w[-f silent nonexistent_dir/**/*.cr]
+        end
+      end
+
+      it "does not raise when reading from STDIN" do
+        # STDIN mode should bypass glob validation
+        opts = CLI.parse_args %w[--stdin-filename foo.cr]
+        opts.stdin_filename.should_not be_nil
       end
     end
 

--- a/spec/ameba/cli/cmd_spec.cr
+++ b/spec/ameba/cli/cmd_spec.cr
@@ -18,8 +18,20 @@ module Ameba::CLI
       end
 
       it "raises when a glob matches no files" do
-        expect_raises(Exception, "No files found matching") do
+        expect_raises(Exception, "No files found matching `#{Path["nonexistent_dir", "**", "*.cr"].relative_to(Dir.current)}`") do
           CLI.run %w[-f silent nonexistent_dir/**/*.cr]
+        end
+      end
+
+      context "with `--ignore-unmatched-paths` flag" do
+        it "does not raise when a non-existent file is provided" do
+          r = CLI.run %w[-f silent --ignore-unmatched-paths not_there.cr]
+          r.should be_true
+        end
+
+        it "does not raise when a non-matching glob is provided" do
+          r = CLI.run %w[-f silent --ignore-unmatched-paths nonexistent_dir/**/*.cr]
+          r.should be_true
         end
       end
 
@@ -107,6 +119,11 @@ module Ameba::CLI
       it "accepts --no-color flag" do
         opts = CLI.parse_args %w[--no-color]
         opts.colors?.should be_false
+      end
+
+      it "accepts --ignore-unmatched-paths flag" do
+        opts = CLI.parse_args %w[--ignore-unmatched-paths]
+        opts.ignore_unmatched_paths?.should be_true
       end
 
       it "accepts --without-affected-code flag" do

--- a/src/ameba/cli/cmd.cr
+++ b/src/ameba/cli/cmd.cr
@@ -69,6 +69,8 @@ module Ameba::CLI
         return true
       end
 
+      validate_globs(opts, config.root)
+
       runner = Ameba.run(config)
 
       if location_to_explain
@@ -306,6 +308,16 @@ module Ameba::CLI
   private def configure_describe_opts(rule_name, opts) : Nil
     opts.describe_rule = rule_name.presence
     opts.formatter = :silent
+  end
+
+  private def validate_globs(opts, root) : Nil
+    return if opts.stdin_filename
+    return unless globs = opts.globs
+
+    globs.each do |glob|
+      next unless GlobUtils.expand({glob}, root).empty?
+      raise "No files found matching `#{Path[glob].relative_to(Dir.current)}`"
+    end
   end
 
   private def configure_explain_opts(loc, opts) : Nil

--- a/src/ameba/cli/cmd.cr
+++ b/src/ameba/cli/cmd.cr
@@ -24,6 +24,7 @@ module Ameba::CLI
     property? all = false
     property? colors = true
     property? without_affected_code = false
+    property? ignore_unmatched_paths = false
     property? autocorrect = false
   end
 
@@ -188,6 +189,11 @@ module Ameba::CLI
         opts.without_affected_code = true
       end
 
+      parser.on("--ignore-unmatched-paths",
+        "Do not report unmatched path patterns") do
+        opts.ignore_unmatched_paths = true
+      end
+
       parser.on("--no-color", "Disable colors") do
         opts.colors = false
       end
@@ -311,6 +317,7 @@ module Ameba::CLI
   end
 
   private def validate_globs(opts, root) : Nil
+    return if opts.ignore_unmatched_paths?
     return if opts.stdin_filename
     return unless globs = opts.globs
 


### PR DESCRIPTION
Resolves #787
Closes #388

Adds `--ignore-unmatched-paths` CLI flag to opt out of the new behaviour.

### Original description

> The intent of this PR is to raise if any of the provided inputs resolve to no files.
> 
> #### Before (silent success — misleading):
> ```
> # Typo in filename — ameba says "all good!" but checked nothing
> $ ameba typo.cr # => exits 0, no errors reported
> 
> # Non-existent directory — same problem
> $ ameba "src/nonexistent/**/*.cr" # => exits 0, no errors reported
> ```
> 
> #### After (clear error):
> ```
> $ ameba typo.cr
> # => raises: "No files found matching `typo.cr`"
> 
> $ ameba "src/nonexistent/**/*.cr"
> # => raises: "No files found matching `src/nonexistent/**/*.cr`"
> ```