### PR TITLE
feat(style/heredoc_escape): add autocorrection

### DIFF
--- a/spec/ameba/rule/style/heredoc_escape_spec.cr
+++ b/spec/ameba/rule/style/heredoc_escape_spec.cr
@@ -45,18 +45,30 @@ module Ameba::Rule::Style
     end
 
     it "fails if a heredoc contains escaped interpolation" do
-      expect_issue subject, <<-'CRYSTAL'
+      source = expect_issue subject, <<-'CRYSTAL'
         <<-HEREDOC
         # ^^^^^^^^ error: Use an escaped heredoc marker: `<<-'HEREDOC'`
+          foo \#{:bar}
+          HEREDOC
+        CRYSTAL
+
+      expect_correction source, <<-'CRYSTAL'
+        <<-'HEREDOC'
           foo \#{:bar}
           HEREDOC
         CRYSTAL
     end
 
     it "fails if a heredoc contains escaped interpolation and escaped escape sequences" do
-      expect_issue subject, <<-'CRYSTAL'
+      source = expect_issue subject, <<-'CRYSTAL'
         <<-HEREDOC
         # ^^^^^^^^ error: Use an escaped heredoc marker: `<<-'HEREDOC'`
+          foo \\t \#{:bar}
+          HEREDOC
+        CRYSTAL
+
+      expect_correction source, <<-'CRYSTAL'
+        <<-'HEREDOC'
           foo \\t \#{:bar}
           HEREDOC
         CRYSTAL
@@ -71,9 +83,15 @@ module Ameba::Rule::Style
     end
 
     it "fails if a heredoc contains escaped escape sequences" do
-      expect_issue subject, <<-'CRYSTAL'
+      source = expect_issue subject, <<-'CRYSTAL'
         <<-HEREDOC
         # ^^^^^^^^ error: Use an escaped heredoc marker: `<<-'HEREDOC'`
+          \\t \\n
+          HEREDOC
+        CRYSTAL
+
+      expect_correction source, <<-'CRYSTAL'
+        <<-'HEREDOC'
           \\t \\n
           HEREDOC
         CRYSTAL
@@ -123,9 +141,15 @@ module Ameba::Rule::Style
     end
 
     it "fails if an escaped heredoc doesn't contain interpolation" do
-      expect_issue subject, <<-CRYSTAL
+      source = expect_issue subject, <<-CRYSTAL
         <<-'HEREDOC'
         # ^^^^^^^^^^ error: Use an unescaped heredoc marker: `<<-HEREDOC`
+          foo
+          HEREDOC
+        CRYSTAL
+
+      expect_correction source, <<-CRYSTAL
+        <<-HEREDOC
           foo
           HEREDOC
         CRYSTAL

--- a/src/ameba/rule/style/heredoc_escape.cr
+++ b/src/ameba/rule/style/heredoc_escape.cr
@@ -48,21 +48,27 @@ module Ameba::Rule::Style
       return unless code = node_source(node, source.lines)
       return unless code.starts_with?("<<-")
 
-      body = code.lines[1..-2].join('\n')
+      lines = code.lines
+      body = lines[1..-2].join('\n')
 
       if code.starts_with?("<<-'")
         return if has_escape_sequence?(expr.value) || has_escaped_escape_sequence?(body)
 
         marker = code.lchop("<<-'").match!(/^(\w+)/)[1]
         msg = MSG_ESCAPE_NOT_NEEDED % marker
+        corrected_marker = "<<-#{marker}"
       else
         return if !has_escape_sequence?(expr.value) || has_escape_sequence?(body)
 
         marker = code.lchop("<<-").match!(/^(\w+)/)[1]
         msg = MSG_ESCAPE_NEEDED % marker
+        corrected_marker = "<<-'#{marker}'"
       end
 
-      issue_for node, msg
+      issue_for node, msg do |corrector|
+        lines[0] = lines[0].sub(/^<<-'?#{marker}'?/, corrected_marker)
+        corrector.replace(node, lines.join('\n'))
+      end
     end
 
     private def has_escape_sequence?(value : String)


### PR DESCRIPTION
Adds autocorrection to `Style/HeredocEscape`, toggling the opening heredoc marker between `<<-MARKER` and `<<-'MARKER'` to match the reported variant. Part of #724.

Specs cover both directions (adding and removing the escape) and a stash-revert confirms they fail without the fix.