### PR TITLE
`Lint/Formatting`: avoid `IndexError` when autocorrecting source with no trailing newline

### DIFF
--- a/spec/ameba/rule/lint/formatting_spec.cr
+++ b/spec/ameba/rule/lint/formatting_spec.cr
@@ -30,6 +30,14 @@ module Ameba::Rule::Lint
         CRYSTAL
     end
 
+    it "does not raise IndexError when source has no trailing newline" do
+      source = Ameba::Source.new("# foo", "test.cr")
+      subject.test(source)
+      source.issues.empty?.should be_false
+      source.correct!
+      source.code.should eq "# foo\n"
+    end
+
     context "properties" do
       context "#fail_on_error" do
         it "passes on formatter errors by default" do

--- a/spec/ameba/rule/lint/formatting_spec.cr
+++ b/spec/ameba/rule/lint/formatting_spec.cr
@@ -30,12 +30,15 @@ module Ameba::Rule::Lint
         CRYSTAL
     end
 
-    it "does not raise IndexError when source has no trailing newline" do
-      source = Ameba::Source.new("# foo", "test.cr")
-      subject.test(source)
-      source.issues.empty?.should be_false
-      source.correct!
-      source.code.should eq "# foo\n"
+    it "successfully formats source with no trailing newline" do
+      source = expect_issue subject, <<-CRYSTAL
+        # foo
+        # ^{} error: Use built-in formatter to format this source
+        CRYSTAL
+
+      expect_correction source, <<-CRYSTAL
+        # foo\n
+        CRYSTAL
     end
 
     context "properties" do

--- a/src/ameba/rule/lint/formatting.cr
+++ b/src/ameba/rule/lint/formatting.cr
@@ -46,13 +46,8 @@ module Ameba::Rule::Lint
       result = Crystal.format(source_code, source.path)
       return if result == source_code
 
-      end_location = {
-        source_lines.size,
-        source_lines.last.size + 1,
-      }
-
       issue_for LOCATION, MSG do |corrector|
-        corrector.replace(LOCATION, end_location, result)
+        corrector.replace(0...source_code.size, result)
       end
     rescue ex : Crystal::SyntaxException
       if fail_on_error?

--- a/src/ameba/rule/lint/formatting.cr
+++ b/src/ameba/rule/lint/formatting.cr
@@ -39,9 +39,7 @@ module Ameba::Rule::Lint
 
     def test(source)
       source_code = source.code
-
-      source_lines = source_code.lines
-      return if source_lines.empty?
+      return if source_code.empty?
 
       result = Crystal.format(source_code, source.path)
       return if result == source_code


### PR DESCRIPTION
# Description

Fixes `Lint/Formatting` autocorrection crashing with `IndexError` on any source file that lacks a trailing newline.

Fixes #514

## Root cause

`Lint/Formatting` computed the replacement range end column as `source_lines.last.size + 1`. Crystal's `String#lines` strips trailing newlines, so for a source like `"# foo"` (5 chars, no trailing newline):

- `source_lines.last.size` = 5
- end column = 6
- `Corrector#replace` converts this to byte offset 5 then adds 1 more (for inclusive-to-exclusive conversion), yielding position 6
- `Rewriter#check_range_validity` raises `IndexError: The range 0...6 is outside the bounds of the source (0...5)`

For sources *with* a trailing newline the +1 happened to be harmless because `code.size` was one larger, but for sources without one it always overshot.

## Fix

Use the range-based `Corrector#replace(0...source_code.size, result)` overload, which directly expresses "replace the entire source" without any line/column arithmetic. This works correctly regardless of whether the source ends with a newline.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Unit tests (added or updated unit-tests)