### PR TITLE
fix: avoid false positives across unconnected branches in `Lint/ShadowingOuterLocalVar`

### DIFF
--- a/spec/ameba/ast/reaching_definition_analyzer_spec.cr
+++ b/spec/ameba/ast/reaching_definition_analyzer_spec.cr
@@ -140,6 +140,55 @@ module Ameba::AST
       end
     end
 
+    context "loops" do
+      it "reaches a block assigned earlier in the same iteration" do
+        reaches?(<<-CRYSTAL, "x").should be_true
+          while cond
+            x = 1
+            foo { |x| }
+          end
+          CRYSTAL
+      end
+
+      it "reaches a block when assigned before the loop" do
+        reaches?(<<-CRYSTAL, "x").should be_true
+          x = 1
+          while cond
+            foo { |x| }
+          end
+          CRYSTAL
+      end
+
+      # Crystal scoping is lexical: a variable assigned later in the body is not
+      # in scope at an earlier point, even though the loop's back edge would
+      # reach it at runtime.
+      it "does not reach a block that precedes the assignment in the body" do
+        reaches?(<<-CRYSTAL, "x").should be_false
+          while cond
+            foo { |x| }
+            x = 1
+          end
+          CRYSTAL
+      end
+
+      it "does not reach a block that precedes the assignment in an until body" do
+        reaches?(<<-CRYSTAL, "x").should be_false
+          until cond
+            foo { |x| }
+            x = 1
+          end
+          CRYSTAL
+      end
+
+      it "does not reach a block in a loop that never assigns the variable" do
+        reaches?(<<-CRYSTAL, "x").should be_false
+          while cond
+            foo { |x| }
+          end
+          CRYSTAL
+      end
+    end
+
     context "captured definitions" do
       it "reaches through a nested block from an outer assignment" do
         reaches?(<<-CRYSTAL, "x").should be_true

--- a/spec/ameba/ast/reaching_definition_analyzer_spec.cr
+++ b/spec/ameba/ast/reaching_definition_analyzer_spec.cr
@@ -2,8 +2,7 @@ require "../../spec_helper"
 
 private def scopes_for(code)
   rule = Ameba::ScopeRule.new
-  source = Ameba::Source.new(code)
-  Ameba::AST::ScopeVisitor.new(rule, source)
+  Ameba::AST::ScopeVisitor.new(rule, Ameba::Source.new(code))
   rule.scopes
 end
 

--- a/spec/ameba/ast/reaching_definition_analyzer_spec.cr
+++ b/spec/ameba/ast/reaching_definition_analyzer_spec.cr
@@ -1,0 +1,169 @@
+require "../../spec_helper"
+
+private def scopes_for(code)
+  rule = Ameba::ScopeRule.new
+  source = Ameba::Source.new(code)
+  Ameba::AST::ScopeVisitor.new(rule, source)
+  rule.scopes
+end
+
+private def reaches?(code, name)
+  inner = scopes_for(code).find! do |scope|
+    (scope.node.is_a?(Crystal::Block) || scope.node.is_a?(Crystal::ProcLiteral)) &&
+      scope.arguments.any?(&.name.== name)
+  end
+  outer = inner.outer_scope || raise "expected an outer scope"
+  outer.declared_at?(name, inner.node)
+end
+
+module Ameba::AST
+  describe ReachingDefinitionAnalyzer do
+    context "sequential flow" do
+      it "reaches a block after the assignment" do
+        reaches?(<<-CRYSTAL, "x").should be_true
+          x = 1
+          foo { |x| }
+          CRYSTAL
+      end
+
+      it "does not reach a block before the assignment" do
+        reaches?(<<-CRYSTAL, "x").should be_false
+          foo { |x| }
+          x = 1
+          CRYSTAL
+      end
+
+      it "does not reach a block nested in its own initializing assignment" do
+        reaches?(<<-CRYSTAL, "x").should be_false
+          x = foo { |x| }
+          CRYSTAL
+      end
+
+      it "reaches through a splat multi-assignment target" do
+        reaches?(<<-CRYSTAL, "x").should be_true
+          a, *x = [1, 2, 3]
+          foo { |x| }
+          CRYSTAL
+      end
+
+      it "reaches an assignment inside a short-circuit operator" do
+        reaches?(<<-CRYSTAL, "x").should be_true
+          done || (x = compute)
+          foo { |x| }
+          CRYSTAL
+      end
+    end
+
+    context "conditional flow" do
+      it "does not reach across mutually exclusive if/else branches" do
+        reaches?(<<-CRYSTAL, "x").should be_false
+          if cond
+            x = 1
+          else
+            foo { |x| }
+          end
+          CRYSTAL
+      end
+
+      it "reaches when assigned before the conditional" do
+        reaches?(<<-CRYSTAL, "x").should be_true
+          x = 1
+          if cond
+            foo { |x| }
+          end
+          CRYSTAL
+      end
+
+      it "reaches when assigned in the condition" do
+        reaches?(<<-CRYSTAL, "x").should be_true
+          if x = compute
+            foo { |x| }
+          end
+          CRYSTAL
+      end
+
+      it "may reach when assigned in only one prior branch" do
+        reaches?(<<-CRYSTAL, "x").should be_true
+          if cond
+            x = 1
+          end
+          foo { |x| }
+          CRYSTAL
+      end
+    end
+
+    context "terminating branches" do
+      it "does not reach past a branch that returns" do
+        reaches?(<<-CRYSTAL, "x").should be_false
+          def foo
+            if cond
+              x = 1
+              return
+            end
+            bar { |x| }
+          end
+          CRYSTAL
+      end
+
+      it "does not reach past a branch that raises" do
+        reaches?(<<-CRYSTAL, "x").should be_false
+          def foo
+            if cond
+              x = 1
+              raise "boom"
+            end
+            bar { |x| }
+          end
+          CRYSTAL
+      end
+
+      it "reaches when the terminating branch does not assign the variable" do
+        reaches?(<<-CRYSTAL, "x").should be_true
+          def foo
+            x = 1
+            return if cond
+            bar { |x| }
+          end
+          CRYSTAL
+      end
+
+      it "reaches a block nested inside a terminating branch" do
+        reaches?(<<-CRYSTAL, "x").should be_true
+          def foo
+            if cond
+              x = 1
+              bar { |x| }
+              return
+            end
+          end
+          CRYSTAL
+      end
+    end
+
+    context "captured definitions" do
+      it "reaches through a nested block from an outer assignment" do
+        reaches?(<<-CRYSTAL, "x").should be_true
+          x = 1
+          foo { bar { |x| } }
+          CRYSTAL
+      end
+
+      it "treats arguments as reaching definitions" do
+        reaches?(<<-CRYSTAL, "x").should be_true
+          def foo(x)
+            bar { |x| }
+          end
+          CRYSTAL
+      end
+
+      it "does not capture across a def boundary" do
+        reaches?(<<-CRYSTAL, "x").should be_false
+          x = 1
+          def foo
+            bar { |x| }
+          end
+          CRYSTAL
+      end
+    end
+  end
+end

--- a/spec/ameba/ast/variabling/variable_spec.cr
+++ b/spec/ameba/ast/variabling/variable_spec.cr
@@ -182,56 +182,5 @@ module Ameba::AST
         variable.eql?(variable.node).should be_true
       end
     end
-
-    describe "#declared_before?" do
-      it "is falsey if variable doesn't have location" do
-        var1 = Crystal::Var.new("foo")
-        var2 = Crystal::Var.new("bar").at(Crystal::Location.new(nil, 1, 2))
-        Variable.new(var1, scope).declared_before?(var2).should be_falsey
-      end
-
-      it "is falsey if node doesn't have location" do
-        var1 = Crystal::Var.new("foo").at(Crystal::Location.new(nil, 1, 2))
-        var2 = Crystal::Var.new("bar")
-        Variable.new(var1, scope).declared_before?(var2).should be_falsey
-      end
-
-      it "is true if var's line_number below the node" do
-        var1 = Crystal::Var.new("foo").at(Crystal::Location.new(nil, 1, 2))
-        var2 = Crystal::Var.new("bar").at(Crystal::Location.new(nil, 2, 2))
-        Variable.new(var1, scope).declared_before?(var2).should be_true
-      end
-
-      it "is true if var's column_number is after the node" do
-        var1 = Crystal::Var.new("foo").at(Crystal::Location.new(nil, 1, 2))
-        var2 = Crystal::Var.new("bar").at(Crystal::Location.new(nil, 1, 3))
-        Variable.new(var1, scope).declared_before?(var2).should be_true
-      end
-
-      it "is false if var's location is before the node" do
-        var1 = Crystal::Var.new("foo").at(Crystal::Location.new(nil, 2, 2))
-        var2 = Crystal::Var.new("bar").at(Crystal::Location.new(nil, 1, 3))
-        Variable.new(var1, scope).declared_before?(var2).should be_false
-      end
-
-      it "is false if the node is the same var" do
-        var = Crystal::Var.new("foo").at(Crystal::Location.new(nil, 2, 2))
-        Variable.new(var, scope).declared_before?(var).should be_false
-      end
-
-      it "uses the first assignment's end location, not the target's location" do
-        target = Crystal::Var.new("x")
-        variable = Variable.new(target, scope)
-        assign = Crystal::Assign.new(target, Crystal::NilLiteral.new)
-          .at_end(Crystal::Location.new(nil, 1, 15))
-        variable.assignments << Assignment.new(assign, variable, scope)
-
-        inside_value = Crystal::Var.new("x").at(Crystal::Location.new(nil, 1, 12))
-        after_value = Crystal::Var.new("x").at(Crystal::Location.new(nil, 2, 1))
-
-        variable.declared_before?(inside_value).should be_false
-        variable.declared_before?(after_value).should be_true
-      end
-    end
   end
 end

--- a/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
+++ b/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
@@ -518,6 +518,37 @@ module Ameba::Rule::Lint
       end
     end
 
+    context "loops" do
+      it "reports when the assignment precedes the block in the body" do
+        expect_issue subject, <<-CRYSTAL
+          while cond
+            x = 1
+            bar { |x| x + 1 }
+                 # ^ error: Shadowing outer local variable `x`
+          end
+          CRYSTAL
+      end
+
+      # The assignment is lexically below the block, so the outer `x` is not in
+      # scope where the block is introduced, even across the loop's back edge.
+      it "does not report when the assignment is lexically below the block" do
+        expect_no_issues subject, <<-CRYSTAL
+          while cond
+            bar { |x| x + 1 }
+            x = 1
+          end
+          CRYSTAL
+      end
+
+      it "does not report when the loop never assigns the shadowed name" do
+        expect_no_issues subject, <<-CRYSTAL
+          while cond
+            bar { |x| x + 1 }
+          end
+          CRYSTAL
+      end
+    end
+
     context "macro" do
       it "does not report shadowed vars in outer scope" do
         expect_no_issues subject, <<-CRYSTAL

--- a/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
+++ b/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
@@ -404,6 +404,120 @@ module Ameba::Rule::Lint
       end
     end
 
+    context "multi-assignment and short-circuit operators" do
+      it "reports when a splat multi-assignment target is shadowed" do
+        expect_issue subject, <<-CRYSTAL
+          a, *foo = [1, 2, 3]
+          bar { |foo| foo }
+               # ^^^ error: Shadowing outer local variable `foo`
+          CRYSTAL
+      end
+
+      it "reports when an assignment inside a short-circuit operator is shadowed" do
+        expect_issue subject, <<-CRYSTAL
+          done || (foo = compute)
+          bar { |foo| foo }
+               # ^^^ error: Shadowing outer local variable `foo`
+          CRYSTAL
+      end
+    end
+
+    context "unconnected (terminating) code branch" do
+      it "does not report when the assignment branch ends in `return`" do
+        expect_no_issues subject, <<-CRYSTAL
+          def foo
+            if cond
+              x = 1
+              return
+            end
+
+            bar { |x| x + 1 }
+          end
+          CRYSTAL
+      end
+
+      it "does not report when the assignment branch ends in `next`" do
+        expect_no_issues subject, <<-CRYSTAL
+          [1, 2].each do |i|
+            if cond
+              x = 1
+              next
+            end
+
+            bar { |x| x + 1 }
+          end
+          CRYSTAL
+      end
+
+      it "does not report when the assignment branch ends in `break`" do
+        expect_no_issues subject, <<-CRYSTAL
+          [1, 2].each do |i|
+            if cond
+              x = 1
+              break
+            end
+
+            bar { |x| x + 1 }
+          end
+          CRYSTAL
+      end
+
+      it "does not report when the assignment branch ends in `raise`" do
+        expect_no_issues subject, <<-CRYSTAL
+          def foo
+            if cond
+              x = 1
+              raise "boom"
+            end
+
+            bar { |x| x + 1 }
+          end
+          CRYSTAL
+      end
+
+      it "does not report when every branch of the assignment is terminating" do
+        expect_no_issues subject, <<-CRYSTAL
+          def foo
+            if cond
+              x = 1
+              return x
+            else
+              x = 2
+              return x
+            end
+
+            bar { |x| x + 1 }
+          end
+          CRYSTAL
+      end
+
+      it "reports when the terminating branch does not assign the variable" do
+        expect_issue subject, <<-CRYSTAL
+          def foo
+            x = 1
+            return if cond
+
+            bar { |x| x + 1 }
+                 # ^ error: Shadowing outer local variable `x`
+          end
+          CRYSTAL
+      end
+
+      it "reports when the assignment is reachable past a nested non-terminating branch" do
+        expect_issue subject, <<-CRYSTAL
+          def foo
+            if cond
+              return if other
+              x = 1
+            end
+
+            bar { |x| x + 1 }
+                 # ^ error: Shadowing outer local variable `x`
+          end
+          CRYSTAL
+      end
+    end
+
     context "macro" do
       it "does not report shadowed vars in outer scope" do
         expect_no_issues subject, <<-CRYSTAL

--- a/src/ameba/ast/dataflow.cr
+++ b/src/ameba/ast/dataflow.cr
@@ -3,33 +3,33 @@ module Ameba::AST
   # generate type-specific handlers, body extraction, and immediate-child
   # collection.
   module Dataflow
-    BRANCH_NODES      = %w[If Unless]
-    LOOP_NODES        = %w[While Until]
-    CASE_NODES        = %w[Case Select]
-    INNER_SCOPE_NODES = %w[
+    private BRANCH_NODES      = %w[If Unless]
+    private LOOP_NODES        = %w[While Until]
+    private CASE_NODES        = %w[Case Select]
+    private INNER_SCOPE_NODES = %w[
       Block Def ProcLiteral ClassDef ModuleDef EnumDef
       LibDef FunDef TypeDef CStructOrUnionDef TypeOf
       Macro MacroIf MacroFor
     ]
 
     # Returns the body node a scope analysis should walk for *node*.
-    # ameba:disable Metrics/CyclomaticComplexity
     def scope_body(node)
       case node
-      when Crystal::Def               then node.body
-      when Crystal::FunDef            then node.body
-      when Crystal::Block             then node.body
-      when Crystal::ClassDef          then node.body
-      when Crystal::ModuleDef         then node.body
-      when Crystal::LibDef            then node.body
-      when Crystal::CStructOrUnionDef then node.body
-      when Crystal::Assign            then node.value
-      when Crystal::OpAssign          then node.value
-      when Crystal::ProcLiteral       then node.def.body
-      when Crystal::EnumDef           then Crystal::Expressions.from(node.members)
-      when Crystal::TypeOf            then Crystal::Expressions.from(node.expressions)
-      when Crystal::Expressions       then node
-      else                                 node
+      when Crystal::Def,
+           Crystal::FunDef,
+           Crystal::Block,
+           Crystal::ClassDef,
+           Crystal::ModuleDef,
+           Crystal::LibDef,
+           Crystal::CStructOrUnionDef
+        node.body
+      when Crystal::Assign, Crystal::OpAssign
+        node.value
+      when Crystal::ProcLiteral then node.def.body
+      when Crystal::EnumDef     then Crystal::Expressions.from(node.members)
+      when Crystal::TypeOf      then Crystal::Expressions.from(node.expressions)
+      when Crystal::Expressions then node
+      else                           node
       end
     end
 

--- a/src/ameba/ast/dataflow.cr
+++ b/src/ameba/ast/dataflow.cr
@@ -1,0 +1,47 @@
+module Ameba::AST
+  # Building blocks for dataflow analysis: the AST node groupings used to
+  # generate type-specific handlers, body extraction, and immediate-child
+  # collection.
+  module Dataflow
+    BRANCH_NODES      = %w[If Unless]
+    LOOP_NODES        = %w[While Until]
+    CASE_NODES        = %w[Case Select]
+    INNER_SCOPE_NODES = %w[
+      Block Def ProcLiteral ClassDef ModuleDef EnumDef
+      LibDef FunDef TypeDef CStructOrUnionDef TypeOf
+      Macro MacroIf MacroFor
+    ]
+
+    # Returns the body node a scope analysis should walk for *node*.
+    # ameba:disable Metrics/CyclomaticComplexity
+    def scope_body(node)
+      case node
+      when Crystal::Def               then node.body
+      when Crystal::FunDef            then node.body
+      when Crystal::Block             then node.body
+      when Crystal::ClassDef          then node.body
+      when Crystal::ModuleDef         then node.body
+      when Crystal::LibDef            then node.body
+      when Crystal::CStructOrUnionDef then node.body
+      when Crystal::Assign            then node.value
+      when Crystal::OpAssign          then node.value
+      when Crystal::ProcLiteral       then node.def.body
+      when Crystal::EnumDef           then Crystal::Expressions.from(node.members)
+      when Crystal::TypeOf            then Crystal::Expressions.from(node.expressions)
+      when Crystal::Expressions       then node
+      else                                 node
+      end
+    end
+
+    # Collects the immediate children of a node without descending into them.
+    class ChildCollector < Crystal::Visitor
+      def initialize(@children : Array(Crystal::ASTNode))
+      end
+
+      def visit(node : Crystal::ASTNode)
+        @children << node
+        false
+      end
+    end
+  end
+end

--- a/src/ameba/ast/liveness_analyzer.cr
+++ b/src/ameba/ast/liveness_analyzer.cr
@@ -8,21 +8,14 @@ module Ameba::AST
   # future). When an assignment is encountered and its target variable is
   # not in the live set, the assignment is marked as a dead store.
   class LivenessAnalyzer
+    include Dataflow
+
     alias LiveSet = Set(String)
 
     # Maximum iterations for fixed-point convergence in loops.
     # In practice, convergence happens in 2-3 iterations since the live set
     # can only grow monotonically and is bounded by the number of variables.
     MAX_FIXED_POINT_ITERATIONS = 100
-
-    BRANCH_NODES      = %w[If Unless]
-    LOOP_NODES        = %w[While Until]
-    CASE_NODES        = %w[Case Select]
-    INNER_SCOPE_NODES = %w[
-      Block Def ProcLiteral ClassDef ModuleDef EnumDef
-      LibDef FunDef TypeDef CStructOrUnionDef TypeOf
-      Macro MacroIf MacroFor
-    ]
 
     @dead_stores = [] of Assignment
     @var_names : Set(String)
@@ -74,26 +67,6 @@ module Ameba::AST
         end
       end
       map
-    end
-
-    # ameba:disable Metrics/CyclomaticComplexity
-    private def scope_body(node)
-      case node
-      when Crystal::Def               then node.body
-      when Crystal::FunDef            then node.body
-      when Crystal::Block             then node.body
-      when Crystal::ClassDef          then node.body
-      when Crystal::ModuleDef         then node.body
-      when Crystal::LibDef            then node.body
-      when Crystal::CStructOrUnionDef then node.body
-      when Crystal::Assign            then node.value
-      when Crystal::OpAssign          then node.value
-      when Crystal::ProcLiteral       then node.def.body
-      when Crystal::EnumDef           then Crystal::Expressions.from(node.members)
-      when Crystal::TypeOf            then Crystal::Expressions.from(node.expressions)
-      when Crystal::Expressions       then node
-      else                                 node
-      end
     end
 
     private def inner_scope_node?(node)
@@ -377,16 +350,6 @@ module Ameba::AST
       end
 
       branch_lives
-    end
-
-    private class ChildCollector < Crystal::Visitor
-      def initialize(@children : Array(Crystal::ASTNode))
-      end
-
-      def visit(node : Crystal::ASTNode)
-        @children << node
-        false
-      end
     end
   end
 end

--- a/src/ameba/ast/reaching_definition_analyzer.cr
+++ b/src/ameba/ast/reaching_definition_analyzer.cr
@@ -1,0 +1,240 @@
+module Ameba::AST
+  # Performs forward dataflow reaching-definition analysis on a scope's AST,
+  # the forward complement of `LivenessAnalyzer`: it answers "which variables
+  # already hold a definition that reaches a given program point?".
+  #
+  # The reaching set is snapshotted at every inner scope node (block, proc,
+  # def, ...), following execution order. At conditional joins the branches are
+  # merged by union, but a branch that ends in a flow command (`return`,
+  # `next`, `break`, `raise`, ...) cannot fall through, so its definitions are
+  # excluded from the merge.
+  class ReachingDefinitionAnalyzer
+    include Util
+
+    alias DefinedSet = Set(String)
+
+    BRANCH_NODES      = %w[If Unless]
+    LOOP_NODES        = %w[While Until]
+    CASE_NODES        = %w[Case Select]
+    INNER_SCOPE_NODES = %w[
+      Block Def ProcLiteral ClassDef ModuleDef EnumDef
+      LibDef FunDef TypeDef CStructOrUnionDef TypeOf
+      Macro MacroIf MacroFor
+    ]
+
+    @definitions = {} of UInt64 => DefinedSet
+    @inner_scope_nodes : Set(UInt64)
+
+    # Creates a new analyzer for *scope*. *entry* is the set of variable names
+    # already defined when the scope is entered (its arguments plus any
+    # captured outer definitions).
+    def initialize(@scope : Scope, @entry : DefinedSet)
+      @inner_scope_nodes = @scope.inner_scopes.map(&.node.object_id).to_set
+    end
+
+    # Returns a mapping of each inner-scope node's `object_id` to the set of
+    # variable names that reach the point where that scope is introduced.
+    def inner_scope_definitions : Hash(UInt64, DefinedSet)
+      @definitions.clear
+      if body = scope_body(@scope.node)
+        propagate(body, @entry)
+      end
+      @definitions
+    end
+
+    # ameba:disable Metrics/CyclomaticComplexity
+    private def scope_body(node)
+      case node
+      when Crystal::Def               then node.body
+      when Crystal::FunDef            then node.body
+      when Crystal::Block             then node.body
+      when Crystal::ClassDef          then node.body
+      when Crystal::ModuleDef         then node.body
+      when Crystal::LibDef            then node.body
+      when Crystal::CStructOrUnionDef then node.body
+      when Crystal::Assign            then node.value
+      when Crystal::OpAssign          then node.value
+      when Crystal::ProcLiteral       then node.def.body
+      when Crystal::EnumDef           then Crystal::Expressions.from(node.members)
+      when Crystal::TypeOf            then Crystal::Expressions.from(node.expressions)
+      when Crystal::Expressions       then node
+      else                                 node
+      end
+    end
+
+    private def propagate(node : Crystal::ASTNode, defined : DefinedSet) : DefinedSet
+      if @inner_scope_nodes.includes?(node.object_id)
+        @definitions[node.object_id] = defined.dup
+        return defined
+      end
+      transfer(node, defined)
+    end
+
+    private def transfer(node : Crystal::Expressions, defined : DefinedSet) : DefinedSet
+      node.expressions.each do |exp|
+        defined = propagate(exp, defined)
+      end
+      defined
+    end
+
+    private def transfer(node : Crystal::Assign | Crystal::OpAssign, defined : DefinedSet) : DefinedSet
+      defined = propagate(node.value, defined)
+      define(node.target, defined)
+    end
+
+    private def transfer(node : Crystal::MultiAssign, defined : DefinedSet) : DefinedSet
+      node.values.each do |value|
+        defined = propagate(value, defined)
+      end
+      node.targets.each do |target|
+        defined = define(target, defined)
+      end
+      defined
+    end
+
+    private def transfer(node : Crystal::UninitializedVar, defined : DefinedSet) : DefinedSet
+      define(node.var, defined)
+    end
+
+    private def transfer(node : Crystal::TypeDeclaration, defined : DefinedSet) : DefinedSet
+      node.value.try { |value| defined = propagate(value, defined) }
+      define(node.var, defined)
+    end
+
+    private def transfer(node : Crystal::Call, defined : DefinedSet) : DefinedSet
+      node.obj.try { |obj| defined = propagate(obj, defined) }
+      node.args.each do |arg|
+        defined = propagate(arg, defined)
+      end
+      node.named_args.try &.each do |named_arg|
+        defined = propagate(named_arg.value, defined)
+      end
+      node.block_arg.try { |arg| defined = propagate(arg, defined) }
+      node.block.try { |block| defined = propagate(block, defined) }
+      defined
+    end
+
+    private def transfer(node : Crystal::BinaryOp, defined : DefinedSet) : DefinedSet
+      defined = propagate(node.left, defined)
+      propagate(node.right, defined)
+    end
+
+    {% for type in BRANCH_NODES %}
+      private def transfer(node : Crystal::{{ type.id }}, defined : DefinedSet) : DefinedSet
+        defined = propagate(node.cond, defined)
+        merge_branches(defined, {node.then, node.else})
+      end
+    {% end %}
+
+    {% for type in LOOP_NODES %}
+      private def transfer(node : Crystal::{{ type.id }}, defined : DefinedSet) : DefinedSet
+        defined = propagate(node.cond, defined)
+        defined | propagate(node.body, defined)
+      end
+    {% end %}
+
+    {% for type in CASE_NODES %}
+      private def transfer(node : Crystal::{{ type.id }}, defined : DefinedSet) : DefinedSet
+        merge_case(node, defined)
+      end
+    {% end %}
+
+    private def transfer(node : Crystal::ExceptionHandler, defined : DefinedSet) : DefinedSet
+      body_defined = propagate(node.body, defined)
+
+      merged = nil
+      if else_node = node.else
+        else_defined = propagate(else_node, body_defined)
+        merged = collect(merged, else_defined) unless terminates?(else_node)
+      else
+        merged = collect(merged, body_defined)
+      end
+
+      rescue_entry = defined | body_defined
+      node.rescues.try &.each do |rescue_node|
+        rescue_defined = propagate(rescue_node.body, rescue_entry)
+        merged = collect(merged, rescue_defined) unless terminates?(rescue_node.body)
+      end
+
+      merged ||= body_defined
+      (ensure_node = node.ensure) ? propagate(ensure_node, merged) : merged
+    end
+
+    {% for type in INNER_SCOPE_NODES %}
+      private def transfer(node : Crystal::{{ type.id }}, defined : DefinedSet) : DefinedSet
+        defined
+      end
+    {% end %}
+
+    private def transfer(node : Crystal::ASTNode, defined : DefinedSet) : DefinedSet
+      children = [] of Crystal::ASTNode
+      node.accept_children(ChildCollector.new(children))
+      children.each do |child|
+        defined = propagate(child, defined)
+      end
+      defined
+    end
+
+    private def define(target, defined : DefinedSet) : DefinedSet
+      target = target.exp if target.is_a?(Crystal::Splat)
+      return defined unless target.is_a?(Crystal::Var)
+
+      defined = defined.dup
+      defined << target.name
+      defined
+    end
+
+    private def merge_branches(base : DefinedSet, branches) : DefinedSet
+      merged = nil
+      branches.each do |branch|
+        branch_defined = propagate(branch, base)
+        merged = collect(merged, branch_defined) unless terminates?(branch)
+      end
+      merged || base
+    end
+
+    private def merge_case(node : Crystal::Case | Crystal::Select, defined : DefinedSet) : DefinedSet
+      base = defined
+      if node.is_a?(Crystal::Case) && (cond = node.cond)
+        base = propagate(cond, base)
+      end
+
+      merged = nil
+      node.whens.each do |when_node|
+        when_defined = base
+        when_node.conds.each do |when_cond|
+          when_defined = propagate(when_cond, when_defined)
+        end
+        when_defined = propagate(when_node.body, when_defined)
+        merged = collect(merged, when_defined) unless terminates?(when_node.body)
+      end
+
+      if else_node = node.else
+        else_defined = propagate(else_node, base)
+        merged = collect(merged, else_defined) unless terminates?(else_node)
+      else
+        merged = collect(merged, base)
+      end
+
+      merged || base
+    end
+
+    private def collect(merged : DefinedSet?, defined : DefinedSet) : DefinedSet
+      merged ? merged | defined : defined.dup
+    end
+
+    private def terminates?(node) : Bool
+      flow_expression?(node, in_loop: true)
+    end
+
+    private class ChildCollector < Crystal::Visitor
+      def initialize(@children : Array(Crystal::ASTNode))
+      end
+
+      def visit(node : Crystal::ASTNode)
+        @children << node
+        false
+      end
+    end
+  end
+end

--- a/src/ameba/ast/reaching_definition_analyzer.cr
+++ b/src/ameba/ast/reaching_definition_analyzer.cr
@@ -10,17 +10,9 @@ module Ameba::AST
   # excluded from the merge.
   class ReachingDefinitionAnalyzer
     include Util
+    include Dataflow
 
     alias DefinedSet = Set(String)
-
-    BRANCH_NODES      = %w[If Unless]
-    LOOP_NODES        = %w[While Until]
-    CASE_NODES        = %w[Case Select]
-    INNER_SCOPE_NODES = %w[
-      Block Def ProcLiteral ClassDef ModuleDef EnumDef
-      LibDef FunDef TypeDef CStructOrUnionDef TypeOf
-      Macro MacroIf MacroFor
-    ]
 
     @definitions = {} of UInt64 => DefinedSet
     @inner_scope_nodes : Set(UInt64)
@@ -40,26 +32,6 @@ module Ameba::AST
         propagate(body, @entry)
       end
       @definitions
-    end
-
-    # ameba:disable Metrics/CyclomaticComplexity
-    private def scope_body(node)
-      case node
-      when Crystal::Def               then node.body
-      when Crystal::FunDef            then node.body
-      when Crystal::Block             then node.body
-      when Crystal::ClassDef          then node.body
-      when Crystal::ModuleDef         then node.body
-      when Crystal::LibDef            then node.body
-      when Crystal::CStructOrUnionDef then node.body
-      when Crystal::Assign            then node.value
-      when Crystal::OpAssign          then node.value
-      when Crystal::ProcLiteral       then node.def.body
-      when Crystal::EnumDef           then Crystal::Expressions.from(node.members)
-      when Crystal::TypeOf            then Crystal::Expressions.from(node.expressions)
-      when Crystal::Expressions       then node
-      else                                 node
-      end
     end
 
     private def propagate(node : Crystal::ASTNode, defined : DefinedSet) : DefinedSet
@@ -225,16 +197,6 @@ module Ameba::AST
 
     private def terminates?(node) : Bool
       flow_expression?(node, in_loop: true)
-    end
-
-    private class ChildCollector < Crystal::Visitor
-      def initialize(@children : Array(Crystal::ASTNode))
-      end
-
-      def visit(node : Crystal::ASTNode)
-        @children << node
-        false
-      end
     end
   end
 end

--- a/src/ameba/ast/reaching_definition_analyzer.cr
+++ b/src/ameba/ast/reaching_definition_analyzer.cr
@@ -21,7 +21,7 @@ module Ameba::AST
     # already defined when the scope is entered (its arguments plus any
     # captured outer definitions).
     def initialize(@scope : Scope, @entry : DefinedSet)
-      @inner_scope_nodes = @scope.inner_scopes.map(&.node.object_id).to_set
+      @inner_scope_nodes = @scope.inner_scopes.to_set(&.node.object_id)
     end
 
     # Returns a mapping of each inner-scope node's `object_id` to the set of
@@ -143,18 +143,24 @@ module Ameba::AST
     private def transfer(node : Crystal::ASTNode, defined : DefinedSet) : DefinedSet
       children = [] of Crystal::ASTNode
       node.accept_children(ChildCollector.new(children))
+
       children.each do |child|
         defined = propagate(child, defined)
       end
       defined
     end
 
-    private def define(target, defined : DefinedSet) : DefinedSet
-      target = target.exp if target.is_a?(Crystal::Splat)
-      return defined unless target.is_a?(Crystal::Var)
-      return defined if defined.includes?(target.name)
-
+    private def define(target : Crystal::Var, defined : DefinedSet) : DefinedSet
+      return defined if target.name.in?(defined)
       defined.dup << target.name
+    end
+
+    private def define(target : Crystal::Splat, defined : DefinedSet) : DefinedSet
+      define(target.exp, defined)
+    end
+
+    private def define(target, defined : DefinedSet) : DefinedSet
+      defined
     end
 
     private def merge_branches(base : DefinedSet, branches) : DefinedSet

--- a/src/ameba/ast/reaching_definition_analyzer.cr
+++ b/src/ameba/ast/reaching_definition_analyzer.cr
@@ -27,7 +27,6 @@ module Ameba::AST
     # Returns a mapping of each inner-scope node's `object_id` to the set of
     # variable names that reach the point where that scope is introduced.
     def inner_scope_definitions : Hash(UInt64, DefinedSet)
-      @definitions.clear
       if body = scope_body(@scope.node)
         propagate(body, @entry)
       end
@@ -99,6 +98,9 @@ module Ameba::AST
     {% end %}
 
     {% for type in LOOP_NODES %}
+      # A loop body is walked once in textual order: a variable assigned later
+      # in the body is not in scope at an earlier point, since Crystal scoping
+      # is lexical and does not extend a definition backwards over the back edge.
       private def transfer(node : Crystal::{{ type.id }}, defined : DefinedSet) : DefinedSet
         defined = propagate(node.cond, defined)
         defined | propagate(node.body, defined)
@@ -150,10 +152,9 @@ module Ameba::AST
     private def define(target, defined : DefinedSet) : DefinedSet
       target = target.exp if target.is_a?(Crystal::Splat)
       return defined unless target.is_a?(Crystal::Var)
+      return defined if defined.includes?(target.name)
 
-      defined = defined.dup
-      defined << target.name
-      defined
+      defined.dup << target.name
     end
 
     private def merge_branches(base : DefinedSet, branches) : DefinedSet

--- a/src/ameba/ast/reaching_definition_analyzer.cr
+++ b/src/ameba/ast/reaching_definition_analyzer.cr
@@ -68,20 +68,28 @@ module Ameba::AST
     end
 
     private def transfer(node : Crystal::TypeDeclaration, defined : DefinedSet) : DefinedSet
-      node.value.try { |value| defined = propagate(value, defined) }
+      node.value.try do |value|
+        defined = propagate(value, defined)
+      end
       define(node.var, defined)
     end
 
     private def transfer(node : Crystal::Call, defined : DefinedSet) : DefinedSet
-      node.obj.try { |obj| defined = propagate(obj, defined) }
+      node.obj.try do |obj|
+        defined = propagate(obj, defined)
+      end
       node.args.each do |arg|
         defined = propagate(arg, defined)
       end
       node.named_args.try &.each do |named_arg|
         defined = propagate(named_arg.value, defined)
       end
-      node.block_arg.try { |arg| defined = propagate(arg, defined) }
-      node.block.try { |block| defined = propagate(block, defined) }
+      node.block_arg.try do |arg|
+        defined = propagate(arg, defined)
+      end
+      node.block.try do |block|
+        defined = propagate(block, defined)
+      end
       defined
     end
 

--- a/src/ameba/ast/scope.cr
+++ b/src/ameba/ast/scope.cr
@@ -34,8 +34,6 @@ module Ameba::AST
     # The actual AST node that represents a current scope.
     getter node : Crystal::ASTNode
 
-    @reaching_definitions : Hash(UInt64, Set(String))?
-
     delegate location, end_location, to_s,
       to: @node
 
@@ -125,9 +123,8 @@ module Ameba::AST
 
     # Reaching definitions snapshotted at each inner scope's node. Computed
     # lazily and memoized, since several inner scopes share the same outer one.
-    protected def reaching_definitions : Hash(UInt64, Set(String))
-      @reaching_definitions ||=
-        ReachingDefinitionAnalyzer.new(self, entry_definitions).inner_scope_definitions
+    protected getter reaching_definitions : Hash(UInt64, Set(String)) do
+      ReachingDefinitionAnalyzer.new(self, entry_definitions).inner_scope_definitions
     end
 
     # The set of variable names already defined when this scope is entered:
@@ -136,7 +133,9 @@ module Ameba::AST
       defined = arguments.to_set(&.name)
 
       if inherited? && (outer = outer_scope)
-        outer.reaching_definitions[node.object_id]?.try { |defs| defined.concat(defs) }
+        outer.reaching_definitions[node.object_id]?.try do |defs|
+          defined.concat(defs)
+        end
       end
 
       defined

--- a/src/ameba/ast/scope.cr
+++ b/src/ameba/ast/scope.cr
@@ -120,7 +120,7 @@ module Ameba::AST
     # scope.declared_at?("foo", block_node)
     # ```
     def declared_at?(name : String, node) : Bool
-      reaching_definitions[node.object_id]?.try(&.includes?(name)) || false
+      !!reaching_definitions[node.object_id]?.try(&.includes?(name))
     end
 
     # Reaching definitions snapshotted at each inner scope's node. Computed
@@ -133,8 +133,7 @@ module Ameba::AST
     # The set of variable names already defined when this scope is entered:
     # its own arguments plus any captured definitions from the outer scope.
     protected def entry_definitions : Set(String)
-      defined = Set(String).new
-      arguments.each { |argument| defined << argument.name }
+      defined = arguments.to_set(&.name)
 
       if inherited? && (outer = outer_scope)
         outer.reaching_definitions[node.object_id]?.try { |defs| defined.concat(defs) }

--- a/src/ameba/ast/scope.cr
+++ b/src/ameba/ast/scope.cr
@@ -34,6 +34,8 @@ module Ameba::AST
     # The actual AST node that represents a current scope.
     getter node : Crystal::ASTNode
 
+    @reaching_definitions : Hash(UInt64, Set(String))?
+
     delegate location, end_location, to_s,
       to: @node
 
@@ -108,6 +110,37 @@ module Ameba::AST
     # ```
     def assign_variable(name, node)
       find_variable(name).try &.assign(node, self)
+    end
+
+    # Returns `true` if a local variable named *name* has a definition that
+    # reaches the program point where *node* (an inner scope's node) is
+    # introduced.
+    #
+    # ```
+    # scope.declared_at?("foo", block_node)
+    # ```
+    def declared_at?(name : String, node) : Bool
+      reaching_definitions[node.object_id]?.try(&.includes?(name)) || false
+    end
+
+    # Reaching definitions snapshotted at each inner scope's node. Computed
+    # lazily and memoized, since several inner scopes share the same outer one.
+    protected def reaching_definitions : Hash(UInt64, Set(String))
+      @reaching_definitions ||=
+        ReachingDefinitionAnalyzer.new(self, entry_definitions).inner_scope_definitions
+    end
+
+    # The set of variable names already defined when this scope is entered:
+    # its own arguments plus any captured definitions from the outer scope.
+    protected def entry_definitions : Set(String)
+      defined = Set(String).new
+      arguments.each { |argument| defined << argument.name }
+
+      if inherited? && (outer = outer_scope)
+        outer.reaching_definitions[node.object_id]?.try { |defs| defined.concat(defs) }
+      end
+
+      defined
     end
 
     # Returns `true` if current scope represents a block (or proc),

--- a/src/ameba/ast/variabling/variable.cr
+++ b/src/ameba/ast/variabling/variable.cr
@@ -134,26 +134,5 @@ module Ameba::AST
         node.name == @node.name &&
         node.location == @node.location
     end
-
-    # Returns `true` if the variable is declared before the `node`.
-    #
-    # A local variable is considered declared once its first assignment
-    # finishes evaluating; a parameter is declared at the point it's
-    # introduced. This is distinct from the variable's lexical `location`:
-    # in `x = foo { |x| }` the outer `x` appears at column 1, but is only
-    # declared after the block runs.
-    def declared_before?(node)
-      var_location, node_location = declaration_location, node.location
-
-      return unless var_location && node_location
-
-      (var_location.line_number < node_location.line_number) ||
-        (var_location.line_number == node_location.line_number &&
-          var_location.column_number < node_location.column_number)
-    end
-
-    private def declaration_location
-      assignments.first?.try(&.end_location) || location
-    end
   end
 end

--- a/src/ameba/rule/lint/shadowing_outer_local_var.cr
+++ b/src/ameba/rule/lint/shadowing_outer_local_var.cr
@@ -53,127 +53,22 @@ module Ameba::Rule::Lint
     private def find_shadowing(source, scope)
       return unless outer_scope = scope.outer_scope
 
-      branch_visitors = {} of UInt64 => BranchPathVisitor
-
       each_argument_node(scope) do |arg|
         # TODO: handle unpacked variables from `Block#unpacks`
         next unless name = arg.name.presence
 
-        variable = outer_scope.find_variable(name)
-
-        next if variable.nil? || !variable.declared_before?(arg)
+        next unless outer_scope.find_variable(name)
+        next unless outer_scope.declared_at?(name, scope.node)
         next if outer_scope.assigns_ivar?(name)
         next if outer_scope.assigns_type_dec_variable?(name)
-        next if mutually_exclusive_branches?(branch_visitors, variable, arg)
 
         issue_for arg.node, MSG % name, prefer_name_location: true
       end
     end
 
-    private def mutually_exclusive_branches?(visitors, variable, arg)
-      return false if variable.assignments.empty?
-
-      scope_node = variable.scope.node
-      visitor = visitors[scope_node.object_id] ||= BranchPathVisitor.new.tap do |v|
-        scope_node.accept(v)
-      end
-
-      arg_path = visitor.paths[arg.node.object_id]
-      variable.assignments.all? do |assignment|
-        diverges?(arg_path, visitor.paths[assignment.node.object_id])
-      end
-    end
-
-    private def diverges?(path1, path2)
-      shared_depth = {path1.size, path2.size}.min
-
-      shared_depth.times do |i|
-        ancestor1, branch1 = path1[i]
-        ancestor2, branch2 = path2[i]
-
-        return false unless ancestor1.same?(ancestor2)
-        return true unless branch1 == branch2
-      end
-
-      false
-    end
-
     private def each_argument_node(scope, &)
       scope.arguments.each do |arg|
         yield arg unless arg.ignored?
-      end
-    end
-
-    private class BranchPathVisitor < Crystal::Visitor
-      alias Segment = Tuple(Crystal::ASTNode, Symbol | Int32)
-      alias Path = Array(Segment)
-
-      getter paths = {} of UInt64 => Path
-
-      def initialize
-        @stack = Path.new
-      end
-
-      def visit(node : Crystal::ASTNode)
-        record(node)
-        true
-      end
-
-      def visit(node : Crystal::If | Crystal::Unless)
-        visit_conditional(node, node.cond, node.then, node.else)
-      end
-
-      def visit(node : Crystal::Case)
-        record(node)
-        node.cond.try &.accept(self)
-        visit_when_branches(node, node.whens, node.else)
-      end
-
-      def visit(node : Crystal::Select)
-        record(node)
-        visit_when_branches(node, node.whens, node.else)
-      end
-
-      def visit(node : Crystal::ExceptionHandler)
-        record(node)
-        node.body.accept(self)
-        node.rescues.try &.each_with_index do |rescue_node, index|
-          enter(node, index) { rescue_node.body.accept(self) }
-        end
-        if else_node = node.else
-          enter(node, :else) { else_node.accept(self) }
-        end
-        node.ensure.try &.accept(self)
-        false
-      end
-
-      private def visit_conditional(node, cond, then_branch, else_branch)
-        record(node)
-        cond.accept(self)
-        enter(node, :then) { then_branch.accept(self) }
-        enter(node, :else) { else_branch.accept(self) }
-        false
-      end
-
-      private def visit_when_branches(node, whens, else_node)
-        whens.each_with_index do |when_node, index|
-          when_node.conds.each &.accept(self)
-          enter(node, index) { when_node.body.accept(self) }
-        end
-        if else_node
-          enter(node, :else) { else_node.accept(self) }
-        end
-        false
-      end
-
-      private def enter(node, branch_id, &)
-        @stack.push({node, branch_id})
-        yield
-        @stack.pop
-      end
-
-      private def record(node)
-        paths[node.object_id] = @stack.dup
       end
     end
   end


### PR DESCRIPTION
Reworks `Lint/ShadowingOuterLocalVar` to decide shadowing through a forward reaching-definition analysis: a block/proc argument is flagged only when an outer assignment can actually reach the point where it is introduced. Branches that terminate (`return`/`next`/`break`/`raise`) no longer leak assignments past them.

closes https://github.com/crystal-ameba/ameba/issues/835