### PR TITLE
Sort doc version index upon addition

### DIFF
--- a/.github/workflows/add-docs-version-to-json-index.yml
+++ b/.github/workflows/add-docs-version-to-json-index.yml
@@ -38,6 +38,7 @@ jobs:
             .versions |= (
               if ( . | map(.name) | index(\"${VERSION}\") | not ) then
                 . += [ {\"name\": \"${VERSION}\", \"url\": \"/ameba/${VERSION}/\", \"released\": ${RELEASED}} ]
+                | sort_by(.name) | reverse | sort_by(.released)
               else
                 .
               end


### PR DESCRIPTION
ATM, the doc [index](https://github.com/crystal-ameba/ameba/blob/gh-pages/versions.json) is not ordered at all, and added versions are pushed to the end of the array.
This PR changes the behaviour, so:

1. Unreleased versions will be displayed on top
2. Released versions will follow in descending order