### PR TITLE
Crystal 1.21 support

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -79,7 +79,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            CRFLAGS=-Dpreview_mt --release
+            CRFLAGS=--release
           platforms: |
             linux/amd64
             linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
-      - run: docker run --rm -v $PWD:/mnt -w /mnt crystallang/crystal:latest-alpine shards build ameba -Dpreview_mt --release --static
+      - run: docker run --rm -v $PWD:/mnt -w /mnt crystallang/crystal:latest-alpine shards build ameba --release --static
       - run: tar zcf ameba-${{ needs.setup.outputs.version }}-linux-musl-$(uname -m).tar.gz -C bin ameba
       - run: gh release -R ${{ github.repository }} upload ${{ github.ref_name }} ameba-${{ needs.setup.outputs.version }}-linux-musl-$(uname -m).tar.gz
 
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: crystal-lang/install-crystal@v1
       - uses: actions/checkout@v7
-      - run: shards build ameba -Dpreview_mt --release
+      - run: shards build ameba --release
       - run: tar zcf ameba-${{ needs.setup.outputs.version }}-darwin-${{ matrix.arch }}.tar.gz -C bin ameba ameba.dwarf
       - run: gh release -R ${{ github.repository }} upload ${{ github.ref_name }} ameba-${{ needs.setup.outputs.version }}-darwin-${{ matrix.arch }}.tar.gz
 
@@ -84,6 +84,6 @@ jobs:
     steps:
       - uses: crystal-lang/install-crystal@v1
       - uses: actions/checkout@v7
-      - run: shards build ameba -Dpreview_mt --release --static
+      - run: shards build ameba --release --static
       - run: cd bin; 7z a -tzip ../ameba-${{ needs.setup.outputs.version }}-windows-msvc-x86_64.zip ameba.exe ameba.pdb
       - run: gh release -R ${{ github.repository }} upload ${{ github.ref_name }} ameba-${{ needs.setup.outputs.version }}-windows-msvc-x86_64.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:edge AS builder
-ARG CRFLAGS="-Dpreview_mt"
+ARG CRFLAGS=""
 RUN apk add --update crystal shards yaml-dev musl-dev make
 RUN mkdir /ameba
 WORKDIR /ameba

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ SHARDS_BIN ?= shards
 INSTALL_BIN ?= /usr/bin/install
 
 # Flags to pass to the Crystal compiler
-CRFLAGS ?= -Dpreview_mt
+CRFLAGS ?=
 
 # The source files to compile
 SRC_SOURCES := $(shell find src -name '*.cr' 2>/dev/null)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
   - [Autocorrection](#autocorrection)
   - [Explain issues](#explain-issues)
   - [Describe rules](#describe-rules)
-  - [Run in parallel](#run-in-parallel)
 - [Installation](#installation)
   - [As a project dependency](#as-a-project-dependency)
   - [OS X](#os-x)
@@ -105,17 +104,6 @@ You can use `--describe` flag to get a detailed description of a rule:
 $ ameba --describe Lint/UselessAssign
 ```
 
-### Run in parallel
-
-Some quick benchmark results measured while running Ameba on Crystal repo:
-
-```sh
-$ CRYSTAL_WORKERS=1 ameba #=> 29.11 seconds
-$ CRYSTAL_WORKERS=2 ameba #=> 19.49 seconds
-$ CRYSTAL_WORKERS=4 ameba #=> 13.48 seconds
-$ CRYSTAL_WORKERS=8 ameba #=> 10.14 seconds
-```
-
 ## Installation
 
 ### As a project dependency
@@ -140,13 +128,13 @@ targets:
 And then run:
 
 ```sh
-$ shards build ameba -Dpreview_mt
+$ shards build ameba
 ```
 
 Alternatively, skip adding `ameba` target and use `crystal build` command directly:
 
 ```sh
-$ crystal build -Dpreview_mt -o bin/ameba lib/ameba/bin/ameba.cr
+$ crystal build -o bin/ameba lib/ameba/bin/ameba.cr
 ```
 
 Both of these will result in a compiled binary placed under `bin/ameba` path.

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -1,5 +1,11 @@
 require "./ameba/cli/cmd"
 
+{% if Fiber.has_constant?(:ExecutionContext) %}
+  Fiber::ExecutionContext
+    .default
+    .resize(Fiber::ExecutionContext.default_workers_count)
+{% end %}
+
 begin
   exit Ameba::CLI.run ? 0 : 1
 rescue ex


### PR DESCRIPTION
- Drops usage of deprecated `-Dpreview_mt` compiler option
- Introduces default parallelism by resizing the default execution context to the logical number of CPU cores—while still respecting the `CRYSTAL_WORKERS` env variable value

> [!NOTE]
> While discouraged, it still supports building with the `-Dpreview_mt` flag _(for the time being)_