### PR TITLE
feat: security rule group

### DIFF
--- a/spec/ameba/base_spec.cr
+++ b/spec/ameba/base_spec.cr
@@ -20,6 +20,7 @@ module Ameba::Rule
           Metrics
           Naming
           Performance
+          Security
           Style
           Typing
         ]

--- a/spec/ameba/rule/security/command_injection_spec.cr
+++ b/spec/ameba/rule/security/command_injection_spec.cr
@@ -18,6 +18,27 @@ module Ameba::Rule::Security
         CRYSTAL
     end
 
+    it "passes when dynamic parts are shell-quoted or safely cast" do
+      expect_no_issues subject, <<-'CRYSTAL'
+        system("ls -l #{Process.quote(path)}")
+        system("kill #{pid.to_i}")
+        CRYSTAL
+    end
+
+    it "respects MinConfidence" do
+      rule = CommandInjection.new
+      rule.min_confidence = "High"
+
+      expect_no_issues rule, <<-'CRYSTAL'
+        system("ls -l #{path}")
+        CRYSTAL
+
+      expect_issue rule, <<-'CRYSTAL'
+        system("cat #{env.params.query["file"]}")
+        # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Shell command built from interpolated string can lead to command injection
+        CRYSTAL
+    end
+
     it "reports system calls with interpolated strings" do
       expect_issue subject, <<-'CRYSTAL'
         system("ls -l #{path}")

--- a/spec/ameba/rule/security/command_injection_spec.cr
+++ b/spec/ameba/rule/security/command_injection_spec.cr
@@ -1,0 +1,41 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Security
+  describe CommandInjection do
+    subject = CommandInjection.new
+
+    it "passes for commands without interpolation" do
+      expect_no_issues subject, <<-CRYSTAL
+        system("ls -la")
+        `date`
+        Process.run("ls", ["-l", path])
+        CRYSTAL
+    end
+
+    it "passes for interpolation of static literals" do
+      expect_no_issues subject, <<-'CRYSTAL'
+        system("ls #{"-la"}")
+        CRYSTAL
+    end
+
+    it "reports system calls with interpolated strings" do
+      expect_issue subject, <<-'CRYSTAL'
+        system("ls -l #{path}")
+        # ^^^^^^^^^^^^^^^^^^^^^ error: Shell command built from interpolated string can lead to command injection
+        CRYSTAL
+    end
+
+    it "reports backtick commands with interpolated strings" do
+      expect_issue subject, <<-'CRYSTAL'
+        `cat #{file}`
+        # ^^^^^^^^^^^ error: Shell command built from interpolated string can lead to command injection
+        CRYSTAL
+    end
+
+    it "passes if source is a spec" do
+      expect_no_issues subject, <<-'CRYSTAL', "source_spec.cr"
+        system("ls -l #{path}")
+        CRYSTAL
+    end
+  end
+end

--- a/spec/ameba/rule/security/hardcoded_secret_spec.cr
+++ b/spec/ameba/rule/security/hardcoded_secret_spec.cr
@@ -1,0 +1,60 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Security
+  describe HardcodedSecret do
+    subject = HardcodedSecret.new
+
+    it "passes for secrets loaded from the environment" do
+      expect_no_issues subject, <<-CRYSTAL
+        password = ENV["DB_PASSWORD"]
+        api_key = config.api_key
+        CRYSTAL
+    end
+
+    it "passes for placeholder values" do
+      expect_no_issues subject, <<-CRYSTAL
+        password = "changeme!"
+        api_key = "<your-api-key>"
+        CRYSTAL
+    end
+
+    it "passes for short values" do
+      expect_no_issues subject, <<-CRYSTAL
+        password = "test"
+        CRYSTAL
+    end
+
+    it "passes for non-secret names" do
+      expect_no_issues subject, <<-CRYSTAL
+        name = "some string value"
+        CRYSTAL
+    end
+
+    it "reports hardcoded secrets in local variables" do
+      expect_issue subject, <<-CRYSTAL
+        password = "s3cr3t_p4ssw0rd"
+        # ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Hardcoded secret detected; load it from the environment or a credentials store
+        CRYSTAL
+    end
+
+    it "reports hardcoded secrets in instance variables" do
+      expect_issue subject, <<-CRYSTAL
+        @api_key = "abcd1234efgh"
+        # ^^^^^^^^^^^^^^^^^^^^^^^ error: Hardcoded secret detected; load it from the environment or a credentials store
+        CRYSTAL
+    end
+
+    it "reports hardcoded secrets in constants" do
+      expect_issue subject, <<-CRYSTAL
+        SECRET_KEY = "supersecretvalue1"
+        # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Hardcoded secret detected; load it from the environment or a credentials store
+        CRYSTAL
+    end
+
+    it "passes if source is a spec" do
+      expect_no_issues subject, <<-CRYSTAL, "source_spec.cr"
+        password = "s3cr3t_p4ssw0rd"
+        CRYSTAL
+    end
+  end
+end

--- a/spec/ameba/rule/security/hardcoded_secret_spec.cr
+++ b/spec/ameba/rule/security/hardcoded_secret_spec.cr
@@ -30,6 +30,12 @@ module Ameba::Rule::Security
         CRYSTAL
     end
 
+    it "passes for names that only contain a secret word as substring" do
+      expect_no_issues subject, <<-CRYSTAL
+        compass = "north by northwest"
+        CRYSTAL
+    end
+
     it "reports hardcoded secrets in local variables" do
       expect_issue subject, <<-CRYSTAL
         password = "s3cr3t_p4ssw0rd"
@@ -48,6 +54,42 @@ module Ameba::Rule::Security
       expect_issue subject, <<-CRYSTAL
         SECRET_KEY = "supersecretvalue1"
         # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Hardcoded secret detected; load it from the environment or a credentials store
+        CRYSTAL
+    end
+
+    it "reports hardcoded secrets in named arguments" do
+      expect_issue subject, <<-CRYSTAL
+        login(password: "s3cr3t_p4ssw0rd")
+            # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Hardcoded secret detected; load it from the environment or a credentials store
+        CRYSTAL
+    end
+
+    it "reports hardcoded secrets in hash literals" do
+      expect_issue subject, <<-CRYSTAL
+        config = {"password" => "s3cr3t_p4ssw0rd"}
+                              # ^^^^^^^^^^^^^^^^^ error: Hardcoded secret detected; load it from the environment or a credentials store
+        CRYSTAL
+    end
+
+    it "reports hardcoded secrets in parameter defaults" do
+      expect_issue subject, <<-CRYSTAL
+        def connect(password = "s3cr3t_p4ssw0rd")
+                             # ^^^^^^^^^^^^^^^^^ error: Hardcoded secret detected; load it from the environment or a credentials store
+        end
+        CRYSTAL
+    end
+
+    it "reports well-known credential formats regardless of the name" do
+      expect_issue subject, <<-CRYSTAL
+        key = "AKIAIOSFODNN7EXAMPLE"
+            # ^^^^^^^^^^^^^^^^^^^^^^ error: Hardcoded AWS access key detected; load it from the environment or a credentials store
+        CRYSTAL
+    end
+
+    it "reports token values once even when assigned to a secret name" do
+      expect_issue subject, <<-CRYSTAL
+        password = "AKIAIOSFODNN7EXAMPLE"
+                 # ^^^^^^^^^^^^^^^^^^^^^^ error: Hardcoded AWS access key detected; load it from the environment or a credentials store
         CRYSTAL
     end
 

--- a/spec/ameba/rule/security/insecure_random_spec.cr
+++ b/spec/ameba/rule/security/insecure_random_spec.cr
@@ -1,0 +1,42 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Security
+  describe InsecureRandom do
+    subject = InsecureRandom.new
+
+    it "passes for Random::Secure" do
+      expect_no_issues subject, <<-CRYSTAL
+        Random::Secure.hex(32)
+        Random::Secure.urlsafe_base64
+        CRYSTAL
+    end
+
+    it "passes for non-token randomness" do
+      expect_no_issues subject, <<-CRYSTAL
+        Random.rand(10)
+        Random.new.rand(10)
+        bytes.hex
+        CRYSTAL
+    end
+
+    it "reports token generation with the default generator" do
+      expect_issue subject, <<-CRYSTAL
+        Random.new.hex(32)
+        # ^^^^^^^^^^^^^^^^ error: Use `Random::Secure` to generate security-sensitive values
+        CRYSTAL
+    end
+
+    it "reports seeded generators" do
+      expect_issue subject, <<-CRYSTAL
+        Random.new(42).base64(32)
+        # ^^^^^^^^^^^^^^^^^^^^^^^ error: Use `Random::Secure` to generate security-sensitive values
+        CRYSTAL
+    end
+
+    it "passes if source is a spec" do
+      expect_no_issues subject, <<-CRYSTAL, "source_spec.cr"
+        Random.new.hex(32)
+        CRYSTAL
+    end
+  end
+end

--- a/spec/ameba/rule/security/no_tls_verify_spec.cr
+++ b/spec/ameba/rule/security/no_tls_verify_spec.cr
@@ -1,0 +1,33 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Security
+  describe NoTlsVerify do
+    subject = NoTlsVerify.new
+
+    it "passes for peer verification" do
+      expect_no_issues subject, <<-CRYSTAL
+        context.verify_mode = OpenSSL::SSL::VerifyMode::PEER
+        CRYSTAL
+    end
+
+    it "reports disabled certificate verification" do
+      expect_issue subject, <<-CRYSTAL
+        context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+                            # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Disabling TLS certificate verification exposes the connection to man-in-the-middle attacks
+        CRYSTAL
+    end
+
+    it "reports the short path form" do
+      expect_issue subject, <<-CRYSTAL
+        VerifyMode::NONE
+        # ^^^^^^^^^^^^^^ error: Disabling TLS certificate verification exposes the connection to man-in-the-middle attacks
+        CRYSTAL
+    end
+
+    it "passes if source is a spec" do
+      expect_no_issues subject, <<-CRYSTAL, "source_spec.cr"
+        context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+        CRYSTAL
+    end
+  end
+end

--- a/spec/ameba/rule/security/sql_injection_spec.cr
+++ b/spec/ameba/rule/security/sql_injection_spec.cr
@@ -23,6 +23,26 @@ module Ameba::Rule::Security
         CRYSTAL
     end
 
+    it "passes when dynamic parts are safely cast" do
+      expect_no_issues subject, <<-'CRYSTAL'
+        db.query("SELECT * FROM users WHERE id = #{id.to_i}")
+        CRYSTAL
+    end
+
+    it "respects MinConfidence" do
+      rule = SqlInjection.new
+      rule.min_confidence = "High"
+
+      expect_no_issues rule, <<-'CRYSTAL'
+        db.query("SELECT * FROM users WHERE id = #{id}")
+        CRYSTAL
+
+      expect_issue rule, <<-'CRYSTAL'
+        db.query("SELECT * FROM users WHERE id = #{env.params.query["id"]}")
+               # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: SQL statement built from interpolated string can lead to SQL injection
+        CRYSTAL
+    end
+
     it "reports queries built from interpolated strings" do
       expect_issue subject, <<-'CRYSTAL'
         db.query("SELECT * FROM users WHERE id = #{id}")

--- a/spec/ameba/rule/security/sql_injection_spec.cr
+++ b/spec/ameba/rule/security/sql_injection_spec.cr
@@ -1,0 +1,46 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Security
+  describe SqlInjection do
+    subject = SqlInjection.new
+
+    it "passes for parameterized queries" do
+      expect_no_issues subject, <<-CRYSTAL
+        db.query("SELECT * FROM users WHERE id = ?", id)
+        db.exec("DELETE FROM users WHERE id = $1", id)
+        CRYSTAL
+    end
+
+    it "passes for non-SQL interpolation" do
+      expect_no_issues subject, <<-'CRYSTAL'
+        puts "Please update #{name} settings"
+        CRYSTAL
+    end
+
+    it "passes for interpolation of static literals" do
+      expect_no_issues subject, <<-'CRYSTAL'
+        db.query("SELECT * FROM #{"users"}")
+        CRYSTAL
+    end
+
+    it "reports queries built from interpolated strings" do
+      expect_issue subject, <<-'CRYSTAL'
+        db.query("SELECT * FROM users WHERE id = #{id}")
+               # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: SQL statement built from interpolated string can lead to SQL injection
+        CRYSTAL
+    end
+
+    it "reports SQL strings built from interpolation outside query calls" do
+      expect_issue subject, <<-'CRYSTAL'
+        sql = "UPDATE users SET name = #{name}"
+            # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: SQL statement built from interpolated string can lead to SQL injection
+        CRYSTAL
+    end
+
+    it "passes if source is a spec" do
+      expect_no_issues subject, <<-'CRYSTAL', "source_spec.cr"
+        db.query("SELECT * FROM users WHERE id = #{id}")
+        CRYSTAL
+    end
+  end
+end

--- a/spec/ameba/rule/security/timing_attack_spec.cr
+++ b/spec/ameba/rule/security/timing_attack_spec.cr
@@ -10,6 +10,12 @@ module Ameba::Rule::Security
         CRYSTAL
     end
 
+    it "passes when both sides are digest calls" do
+      expect_no_issues subject, <<-CRYSTAL
+        Digest::SHA256.hexdigest(a) == Digest::SHA256.hexdigest(b)
+        CRYSTAL
+    end
+
     it "passes for comparison of non-digest values" do
       expect_no_issues subject, <<-CRYSTAL
         a == b

--- a/spec/ameba/rule/security/timing_attack_spec.cr
+++ b/spec/ameba/rule/security/timing_attack_spec.cr
@@ -1,0 +1,47 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Security
+  describe TimingAttack do
+    subject = TimingAttack.new
+
+    it "passes for constant-time comparison" do
+      expect_no_issues subject, <<-CRYSTAL
+        Crypto::Subtle.constant_time_compare(signature, expected)
+        CRYSTAL
+    end
+
+    it "passes for comparison of non-digest values" do
+      expect_no_issues subject, <<-CRYSTAL
+        a == b
+        name == "admin"
+        CRYSTAL
+    end
+
+    it "reports digest comparison with ==" do
+      expect_issue subject, <<-CRYSTAL
+        signature == OpenSSL::HMAC.hexdigest(:sha256, key, data)
+        # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Comparing digests with `==` is vulnerable to timing attacks; use `Crypto::Subtle.constant_time_compare`
+        CRYSTAL
+    end
+
+    it "reports digest comparison with the digest on the left" do
+      expect_issue subject, <<-CRYSTAL
+        Digest::SHA256.hexdigest(data) == signature
+        # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Comparing digests with `==` is vulnerable to timing attacks; use `Crypto::Subtle.constant_time_compare`
+        CRYSTAL
+    end
+
+    it "reports digest comparison with !=" do
+      expect_issue subject, <<-CRYSTAL
+        a != b.digest
+        # ^^^^^^^^^^^ error: Comparing digests with `!=` is vulnerable to timing attacks; use `Crypto::Subtle.constant_time_compare`
+        CRYSTAL
+    end
+
+    it "passes if source is a spec" do
+      expect_no_issues subject, <<-CRYSTAL, "source_spec.cr"
+        signature == OpenSSL::HMAC.hexdigest(:sha256, key, data)
+        CRYSTAL
+    end
+  end
+end

--- a/spec/ameba/rule/security/weak_crypto_spec.cr
+++ b/spec/ameba/rule/security/weak_crypto_spec.cr
@@ -1,0 +1,47 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Security
+  describe WeakCrypto do
+    subject = WeakCrypto.new
+
+    it "passes for strong hash algorithms" do
+      expect_no_issues subject, <<-CRYSTAL
+        Digest::SHA256.hexdigest(data)
+        OpenSSL::Digest.new("SHA256")
+        CRYSTAL
+    end
+
+    it "passes for non-digest paths with matching names" do
+      expect_no_issues subject, <<-CRYSTAL
+        Foo::MD5.checksum(data)
+        CRYSTAL
+    end
+
+    it "reports MD5 digest usage" do
+      expect_issue subject, <<-CRYSTAL
+        Digest::MD5.hexdigest(data)
+        # ^^^^^^^^^ error: Weak hash algorithm `MD5` is not suitable for security purposes
+        CRYSTAL
+    end
+
+    it "reports SHA1 digest usage" do
+      expect_issue subject, <<-CRYSTAL
+        Digest::SHA1.digest(data)
+        # ^^^^^^^^^^ error: Weak hash algorithm `SHA1` is not suitable for security purposes
+        CRYSTAL
+    end
+
+    it "reports weak OpenSSL digests" do
+      expect_issue subject, <<-CRYSTAL
+        OpenSSL::Digest.new("md5")
+        # ^^^^^^^^^^^^^^^^^^^^^^^^ error: Weak hash algorithm `MD5` is not suitable for security purposes
+        CRYSTAL
+    end
+
+    it "passes if source is a spec" do
+      expect_no_issues subject, <<-CRYSTAL, "source_spec.cr"
+        Digest::MD5.hexdigest(data)
+        CRYSTAL
+    end
+  end
+end

--- a/src/ameba/ast/visitors/node_visitor.cr
+++ b/src/ameba/ast/visitors/node_visitor.cr
@@ -37,6 +37,7 @@ module Ameba::AST
       ModuleDef,
       MultiAssign,
       NilLiteral,
+      Path,
       ProcLiteral,
       Rescue,
       Select,

--- a/src/ameba/config/rule_config.cr
+++ b/src/ameba/config/rule_config.cr
@@ -201,6 +201,7 @@ class Ameba::Config
         Lint:        Ameba::Severity::Warning,
         Metrics:     Ameba::Severity::Warning,
         Performance: Ameba::Severity::Warning,
+        Security:    Ameba::Severity::Error,
       }
 
       class_getter default_severity : Ameba::Severity do

--- a/src/ameba/rule/security/base.cr
+++ b/src/ameba/rule/security/base.cr
@@ -2,9 +2,13 @@ require "../base"
 
 module Ameba::Rule::Security
   # A general base class for security rules.
+  # Spec files are not inspected: test fixtures are full of
+  # placeholder secrets and command snippets.
   abstract class Base < Ameba::Rule::Base
-    def catch(source : Source)
-      source.spec? ? source : super
+    def test(source : Source)
+      return if source.spec?
+
+      super
     end
   end
 end

--- a/src/ameba/rule/security/base.cr
+++ b/src/ameba/rule/security/base.cr
@@ -11,4 +11,60 @@ module Ameba::Rule::Security
       super
     end
   end
+
+  # How likely a security finding is a true positive,
+  # based on the shape of the expression that triggered it.
+  enum Confidence
+    Low
+    Medium
+    High
+  end
+
+  # Classifies expressions by how likely they carry user-controlled input:
+  #
+  # - `High` - the expression reads external input directly
+  #   (`env.params`, `request.headers`, `ARGV`, `STDIN.gets`, ...)
+  # - `Medium` - a variable whose origin is unknown
+  # - `Low` - any other expression (method calls, constants, ...)
+  module EvidenceClassifier
+    INPUT_CALL_NAMES  = %w[params query_params form_params body headers cookies request gets read_line]
+    INPUT_CONST_NAMES = %w[ARGV STDIN]
+
+    SAFE_CAST_NAMES = %w[to_i to_i8 to_i16 to_i32 to_i64 to_u to_u8 to_u16 to_u32 to_u64 to_f to_f32 to_f64]
+
+    def confidence_for(nodes : Enumerable) : Confidence
+      nodes.max_of { |node| confidence_for(node) }
+    end
+
+    def confidence_for(node : Crystal::ASTNode) : Confidence
+      case node
+      when Crystal::Call
+        input_call?(node) ? Confidence::High : Confidence::Low
+      when Crystal::Var, Crystal::InstanceVar, Crystal::ClassVar
+        Confidence::Medium
+      when Crystal::Path
+        input_const?(node) ? Confidence::High : Confidence::Low
+      else
+        Confidence::Medium
+      end
+    end
+
+    def input_call?(node : Crystal::Call) : Bool
+      return true if node.name.in?(INPUT_CALL_NAMES)
+
+      case obj = node.obj
+      when Crystal::Call then input_call?(obj)
+      when Crystal::Path then input_const?(obj)
+      else                    false
+      end
+    end
+
+    def input_const?(node : Crystal::Path) : Bool
+      node.names.first.in?(INPUT_CONST_NAMES)
+    end
+
+    def safe_cast?(node : Crystal::ASTNode) : Bool
+      node.is_a?(Crystal::Call) && node.name.in?(SAFE_CAST_NAMES)
+    end
+  end
 end

--- a/src/ameba/rule/security/base.cr
+++ b/src/ameba/rule/security/base.cr
@@ -1,0 +1,10 @@
+require "../base"
+
+module Ameba::Rule::Security
+  # A general base class for security rules.
+  abstract class Base < Ameba::Rule::Base
+    def catch(source : Source)
+      source.spec? ? source : super
+    end
+  end
+end

--- a/src/ameba/rule/security/command_injection.cr
+++ b/src/ameba/rule/security/command_injection.cr
@@ -21,6 +21,16 @@ module Ameba::Rule::Security
   # File.read(file)
   # ```
   #
+  # Interpolations are not reported when every dynamic part is escaped
+  # with `Process.quote` or converted to a number (`to_i`, `to_f`, ...).
+  #
+  # Every issue carries a confidence based on the interpolated expression:
+  # `High` when it reads external input directly (`env.params`, `ARGV`, ...),
+  # `Medium` for a variable, `Low` for other expressions. Issues below
+  # `MinConfidence` are not reported.
+  #
+  # Reference: [CWE-78](https://cwe.mitre.org/data/definitions/78.html)
+  #
   # YAML configuration example:
   #
   # ```
@@ -28,14 +38,17 @@ module Ameba::Rule::Security
   #   Enabled: true
   #   CommandCallNames:
   #     - system
+  #   MinConfidence: Low
   # ```
   class CommandInjection < Base
     include AST::Util
+    include EvidenceClassifier
 
     properties do
       since_version "1.7.0"
       description "Disallows shell commands built from interpolated strings"
       command_call_names %w[system]
+      min_confidence "Low"
     end
 
     MSG = "Shell command built from interpolated string can lead to command injection"
@@ -44,7 +57,12 @@ module Ameba::Rule::Security
 
     def test(source, node : Crystal::Call)
       return unless command_call?(node)
-      return unless node.args.any? { |arg| dynamic_interpolation?(arg) }
+
+      parts = node.args
+        .select(Crystal::StringInterpolation)
+        .flat_map { |arg| dynamic_parts(arg) }
+      return if parts.empty?
+      return if confidence_for(parts) < Confidence.parse(min_confidence)
 
       issue_for(node, MSG)
     end
@@ -54,8 +72,17 @@ module Ameba::Rule::Security
         (node.name.in?(command_call_names) && node.obj.nil?)
     end
 
-    private def dynamic_interpolation?(node)
-      node.is_a?(Crystal::StringInterpolation) && !static_literal?(node)
+    private def dynamic_parts(node)
+      node.expressions.reject do |exp|
+        static_literal?(exp) || safe_cast?(exp) || shell_quoted?(exp)
+      end
+    end
+
+    private def shell_quoted?(node)
+      node.is_a?(Crystal::Call) &&
+        node.name == "quote" &&
+        (obj = node.obj).is_a?(Crystal::Path) &&
+        obj.names.last == "Process"
     end
   end
 end

--- a/src/ameba/rule/security/command_injection.cr
+++ b/src/ameba/rule/security/command_injection.cr
@@ -1,0 +1,61 @@
+require "./base"
+
+module Ameba::Rule::Security
+  # A rule that disallows shell commands built from interpolated strings.
+  #
+  # Interpolating a value into a shell command makes it possible for
+  # an attacker to execute arbitrary commands if the value is not trusted.
+  #
+  # For example, these are considered insecure:
+  #
+  # ```
+  # system("ls -l #{path}")
+  # `cat #{file}`
+  # ```
+  #
+  # And should be written by passing arguments separately, so they
+  # never go through the shell:
+  #
+  # ```
+  # Process.run("ls", ["-l", path])
+  # File.read(file)
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Security/CommandInjection:
+  #   Enabled: true
+  #   CommandCallNames:
+  #     - system
+  # ```
+  class CommandInjection < Base
+    include AST::Util
+
+    properties do
+      since_version "1.7.0"
+      description "Disallows shell commands built from interpolated strings"
+      command_call_names %w[system]
+    end
+
+    MSG = "Shell command built from interpolated string can lead to command injection"
+
+    BACKTICK_CALL_NAME = "`"
+
+    def test(source, node : Crystal::Call)
+      return unless command_call?(node)
+      return unless node.args.any? { |arg| dynamic_interpolation?(arg) }
+
+      issue_for(node, MSG)
+    end
+
+    private def command_call?(node)
+      node.name == BACKTICK_CALL_NAME ||
+        (node.name.in?(command_call_names) && node.obj.nil?)
+    end
+
+    private def dynamic_interpolation?(node)
+      node.is_a?(Crystal::StringInterpolation) && !static_literal?(node)
+    end
+  end
+end

--- a/src/ameba/rule/security/hardcoded_secret.cr
+++ b/src/ameba/rule/security/hardcoded_secret.cr
@@ -1,0 +1,64 @@
+require "./base"
+
+module Ameba::Rule::Security
+  # A rule that disallows hardcoded secret values.
+  #
+  # Credentials committed to the repository are visible to anyone
+  # with read access to the code and its full history. Load them
+  # from the environment or a credentials store instead.
+  #
+  # For example, this is considered insecure:
+  #
+  # ```
+  # password = "s3cr3t_p4ssw0rd"
+  # ```
+  #
+  # And should be written as:
+  #
+  # ```
+  # password = ENV["DB_PASSWORD"]
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Security/HardcodedSecret:
+  #   Enabled: true
+  #   SecretNamePattern: (password|passwd|secret|api_key|apikey|access_key|private_key|auth_token|credentials?)
+  #   MinLength: 8
+  # ```
+  class HardcodedSecret < Base
+    properties do
+      since_version "1.7.0"
+      description "Disallows hardcoded secret values"
+      secret_name_pattern "(password|passwd|secret|api_key|apikey|access_key|private_key|auth_token|credentials?)"
+      min_length 8
+    end
+
+    MSG = "Hardcoded secret detected; load it from the environment or a credentials store"
+
+    PLACEHOLDER_PATTERN = /example|sample|changeme|placeholder|dummy|x{4,}|\*{3,}|<[^>]+>/i
+
+    def test(source, node : Crystal::Assign)
+      return unless name = target_name(node.target)
+      return unless name.matches?(/#{secret_name_pattern}/i)
+      return unless (value = node.value).is_a?(Crystal::StringLiteral)
+      return unless suspicious?(value.value)
+
+      issue_for(node, MSG)
+    end
+
+    private def target_name(target)
+      case target
+      when Crystal::Var, Crystal::InstanceVar, Crystal::ClassVar
+        target.name
+      when Crystal::Path
+        target.names.last
+      end
+    end
+
+    private def suspicious?(value)
+      value.size >= min_length && !value.matches?(PLACEHOLDER_PATTERN)
+    end
+  end
+end

--- a/src/ameba/rule/security/hardcoded_secret.cr
+++ b/src/ameba/rule/security/hardcoded_secret.cr
@@ -7,10 +7,21 @@ module Ameba::Rule::Security
   # with read access to the code and its full history. Load them
   # from the environment or a credentials store instead.
   #
-  # For example, this is considered insecure:
+  # Two kinds of secrets are detected:
+  #
+  # 1. String literals matching well-known credential formats
+  #    (AWS access keys, GitHub/Slack/Stripe tokens, private keys),
+  #    regardless of where they appear.
+  # 2. String literals assigned to secret-named targets: local,
+  #    instance and class variables, constants, named arguments,
+  #    hash keys, and method parameter defaults.
+  #
+  # For example, these are considered insecure:
   #
   # ```
   # password = "s3cr3t_p4ssw0rd"
+  # login(password: "s3cr3t_p4ssw0rd")
+  # key = "AKIAIOSFODNN7EXAMPLE1"
   # ```
   #
   # And should be written as:
@@ -19,33 +30,86 @@ module Ameba::Rule::Security
   # password = ENV["DB_PASSWORD"]
   # ```
   #
+  # The name pattern matches whole words only (`api_key` matches,
+  # `compass` does not), and values shorter than `MinLength` or
+  # looking like placeholders are ignored.
+  #
+  # Reference: [CWE-798](https://cwe.mitre.org/data/definitions/798.html)
+  #
   # YAML configuration example:
   #
   # ```
   # Security/HardcodedSecret:
   #   Enabled: true
-  #   SecretNamePattern: (password|passwd|secret|api_key|apikey|access_key|private_key|auth_token|credentials?)
+  #   SecretNamePattern: password|passwd|secret|api_key|apikey|access_key|private_key|auth_token|credentials?
   #   MinLength: 8
   # ```
   class HardcodedSecret < Base
     properties do
       since_version "1.7.0"
       description "Disallows hardcoded secret values"
-      secret_name_pattern "(password|passwd|secret|api_key|apikey|access_key|private_key|auth_token|credentials?)"
+      secret_name_pattern "password|passwd|secret|api_key|apikey|access_key|private_key|auth_token|credentials?"
       min_length 8
     end
 
-    MSG = "Hardcoded secret detected; load it from the environment or a credentials store"
+    MSG       = "Hardcoded secret detected; load it from the environment or a credentials store"
+    MSG_TOKEN = "Hardcoded %s detected; load it from the environment or a credentials store"
 
     PLACEHOLDER_PATTERN = /example|sample|changeme|placeholder|dummy|x{4,}|\*{3,}|<[^>]+>/i
 
+    TOKEN_PATTERNS = {
+      /\bAKIA[0-9A-Z]{16}\b/                     => "AWS access key",
+      /\b(?:ghp|gho|ghu|ghs)_[A-Za-z0-9]{36,}\b/ => "GitHub token",
+      /\bgithub_pat_[A-Za-z0-9_]{22,}\b/         => "GitHub token",
+      /\bsk_live_[A-Za-z0-9]{20,}\b/             => "Stripe live key",
+      /\bAIza[0-9A-Za-z\-_]{35}\b/               => "Google API key",
+      /\bxox[pborsa]-[A-Za-z0-9-]{10,}\b/        => "Slack token",
+      /-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----/  => "private key",
+    }
+
+    def test(source, node : Crystal::StringLiteral)
+      return unless label = token_label(node.value)
+
+      issue_for(node, MSG_TOKEN % label)
+    end
+
     def test(source, node : Crystal::Assign)
-      return unless name = target_name(node.target)
-      return unless name.matches?(/#{secret_name_pattern}/i)
-      return unless (value = node.value).is_a?(Crystal::StringLiteral)
+      check(source, node, target_name(node.target), node.value)
+    end
+
+    def test(source, node : Crystal::Call)
+      node.named_args.try &.each do |arg|
+        check(source, arg, arg.name, arg.value)
+      end
+    end
+
+    def test(source, node : Crystal::HashLiteral)
+      node.entries.each do |entry|
+        check(source, entry.value, key_name(entry.key), entry.value)
+      end
+    end
+
+    def test(source, node : Crystal::Def)
+      node.args.each do |arg|
+        next unless value = arg.default_value
+
+        check(source, value, arg.name, value)
+      end
+    end
+
+    private def check(source, node, name, value)
+      return unless name && secret_name?(name)
+      return unless value.is_a?(Crystal::StringLiteral)
+      return if token_label(value.value)
       return unless suspicious?(value.value)
 
       issue_for(node, MSG)
+    end
+
+    private def token_label(value)
+      TOKEN_PATTERNS.each do |pattern, label|
+        return label if value.matches?(pattern)
+      end
     end
 
     private def target_name(target)
@@ -55,6 +119,17 @@ module Ameba::Rule::Security
       when Crystal::Path
         target.names.last
       end
+    end
+
+    private def key_name(key)
+      case key
+      when Crystal::StringLiteral then key.value
+      when Crystal::SymbolLiteral then key.value
+      end
+    end
+
+    private def secret_name?(name)
+      name.matches?(/(?:^|[^a-z0-9])(?:#{secret_name_pattern})(?:[^a-z0-9]|$)/i)
     end
 
     private def suspicious?(value)

--- a/src/ameba/rule/security/insecure_random.cr
+++ b/src/ameba/rule/security/insecure_random.cr
@@ -21,6 +21,8 @@ module Ameba::Rule::Security
   # token = Random::Secure.hex(32)
   # ```
   #
+  # Reference: [CWE-338](https://cwe.mitre.org/data/definitions/338.html)
+  #
   # YAML configuration example:
   #
   # ```

--- a/src/ameba/rule/security/insecure_random.cr
+++ b/src/ameba/rule/security/insecure_random.cr
@@ -1,0 +1,67 @@
+require "./base"
+
+module Ameba::Rule::Security
+  # A rule that disallows the default pseudo-random generator for
+  # security-sensitive values.
+  #
+  # `Random` is a fast pseudo-random generator whose output can be
+  # predicted, which makes tokens, session ids and other secrets
+  # generated with it guessable. `Random::Secure` uses the system
+  # CSPRNG and should be used instead.
+  #
+  # For example, this is considered insecure:
+  #
+  # ```
+  # token = Random.new.hex(32)
+  # ```
+  #
+  # And should be written as:
+  #
+  # ```
+  # token = Random::Secure.hex(32)
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Security/InsecureRandom:
+  #   Enabled: true
+  #   TokenMethodNames:
+  #     - hex
+  #     - base64
+  #     - urlsafe_base64
+  #     - random_bytes
+  # ```
+  class InsecureRandom < Base
+    properties do
+      since_version "1.7.0"
+      description "Disallows `Random` for security-sensitive values"
+      token_method_names %w[hex base64 urlsafe_base64 random_bytes]
+    end
+
+    MSG = "Use `Random::Secure` to generate security-sensitive values"
+
+    RANDOM_PATH             = %w[Random]
+    RANDOM_CONSTRUCTOR_NAME = "new"
+
+    def test(source, node : Crystal::Call)
+      return unless node.name.in?(token_method_names)
+      return unless insecure_random?(node.obj)
+
+      issue_for(node, MSG)
+    end
+
+    private def insecure_random?(obj)
+      case obj
+      when Crystal::Path
+        obj.names == RANDOM_PATH
+      when Crystal::Call
+        obj.name == RANDOM_CONSTRUCTOR_NAME &&
+          (path = obj.obj).is_a?(Crystal::Path) &&
+          path.names == RANDOM_PATH
+      else
+        false
+      end
+    end
+  end
+end

--- a/src/ameba/rule/security/no_tls_verify.cr
+++ b/src/ameba/rule/security/no_tls_verify.cr
@@ -15,6 +15,8 @@ module Ameba::Rule::Security
   # If a peer without a valid certificate must be reached in
   # a controlled environment, disable this rule inline.
   #
+  # Reference: [CWE-295](https://cwe.mitre.org/data/definitions/295.html)
+  #
   # YAML configuration example:
   #
   # ```

--- a/src/ameba/rule/security/no_tls_verify.cr
+++ b/src/ameba/rule/security/no_tls_verify.cr
@@ -1,0 +1,40 @@
+require "./base"
+
+module Ameba::Rule::Security
+  # A rule that disallows disabling TLS certificate verification.
+  #
+  # Setting the verify mode to `NONE` accepts any certificate,
+  # which exposes the connection to man-in-the-middle attacks.
+  #
+  # For example, this is considered insecure:
+  #
+  # ```
+  # context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+  # ```
+  #
+  # If a peer without a valid certificate must be reached in
+  # a controlled environment, disable this rule inline.
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Security/NoTlsVerify:
+  #   Enabled: true
+  # ```
+  class NoTlsVerify < Base
+    properties do
+      since_version "1.7.0"
+      description "Disallows disabling TLS certificate verification"
+    end
+
+    MSG = "Disabling TLS certificate verification exposes the connection to man-in-the-middle attacks"
+
+    VERIFY_NONE_PATH = %w[VerifyMode NONE]
+
+    def test(source, node : Crystal::Path)
+      return unless node.names.last(2) == VERIFY_NONE_PATH
+
+      issue_for(node, MSG)
+    end
+  end
+end

--- a/src/ameba/rule/security/sql_injection.cr
+++ b/src/ameba/rule/security/sql_injection.cr
@@ -1,0 +1,53 @@
+require "./base"
+
+module Ameba::Rule::Security
+  # A rule that disallows SQL statements built from interpolated strings.
+  #
+  # Interpolating a value into a SQL statement makes it possible for
+  # an attacker to read or modify data if the value is not trusted.
+  #
+  # For example, this is considered insecure:
+  #
+  # ```
+  # db.query("SELECT * FROM users WHERE name = '#{name}'")
+  # ```
+  #
+  # And should be written using query parameters:
+  #
+  # ```
+  # db.query("SELECT * FROM users WHERE name = ?", name)
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Security/SqlInjection:
+  #   Enabled: true
+  # ```
+  class SqlInjection < Base
+    include AST::Util
+
+    properties do
+      since_version "1.7.0"
+      description "Disallows SQL statements built from interpolated strings"
+    end
+
+    MSG = "SQL statement built from interpolated string can lead to SQL injection"
+
+    SQL_PATTERN = /\bSELECT\s.+?\sFROM\b|\bINSERT\s+INTO\b|\bUPDATE\s+\S+\s+SET\b|\bDELETE\s+FROM\b/im
+
+    def test(source, node : Crystal::StringInterpolation)
+      return if static_literal?(node)
+      return unless sql_like?(node)
+
+      issue_for(node, MSG)
+    end
+
+    private def sql_like?(node)
+      node.expressions
+        .select(Crystal::StringLiteral)
+        .join(' ', &.value)
+        .matches?(SQL_PATTERN)
+    end
+  end
+end

--- a/src/ameba/rule/security/sql_injection.cr
+++ b/src/ameba/rule/security/sql_injection.cr
@@ -18,18 +18,31 @@ module Ameba::Rule::Security
   # db.query("SELECT * FROM users WHERE name = ?", name)
   # ```
   #
+  # Interpolations are not reported when every dynamic part is
+  # converted to a number (`to_i`, `to_f`, ...).
+  #
+  # Every issue carries a confidence based on the interpolated expression:
+  # `High` when it reads external input directly (`env.params`, `ARGV`, ...),
+  # `Medium` for a variable, `Low` for other expressions. Issues below
+  # `MinConfidence` are not reported.
+  #
+  # Reference: [CWE-89](https://cwe.mitre.org/data/definitions/89.html)
+  #
   # YAML configuration example:
   #
   # ```
   # Security/SqlInjection:
   #   Enabled: true
+  #   MinConfidence: Low
   # ```
   class SqlInjection < Base
     include AST::Util
+    include EvidenceClassifier
 
     properties do
       since_version "1.7.0"
       description "Disallows SQL statements built from interpolated strings"
+      min_confidence "Low"
     end
 
     MSG = "SQL statement built from interpolated string can lead to SQL injection"
@@ -37,8 +50,11 @@ module Ameba::Rule::Security
     SQL_PATTERN = /\bSELECT\s.+?\sFROM\b|\bINSERT\s+INTO\b|\bUPDATE\s+\S+\s+SET\b|\bDELETE\s+FROM\b/im
 
     def test(source, node : Crystal::StringInterpolation)
-      return if static_literal?(node)
       return unless sql_like?(node)
+
+      parts = dynamic_parts(node)
+      return if parts.empty?
+      return if confidence_for(parts) < Confidence.parse(min_confidence)
 
       issue_for(node, MSG)
     end
@@ -48,6 +64,12 @@ module Ameba::Rule::Security
         .select(Crystal::StringLiteral)
         .join(' ', &.value)
         .matches?(SQL_PATTERN)
+    end
+
+    private def dynamic_parts(node)
+      node.expressions.reject do |exp|
+        static_literal?(exp) || safe_cast?(exp)
+      end
     end
   end
 end

--- a/src/ameba/rule/security/timing_attack.cr
+++ b/src/ameba/rule/security/timing_attack.cr
@@ -1,0 +1,59 @@
+require "./base"
+
+module Ameba::Rule::Security
+  # A rule that disallows non-constant-time comparison of digests.
+  #
+  # Comparing a digest or HMAC signature with `==` returns as soon as
+  # the first byte differs, so an attacker can recover the expected
+  # value byte by byte from response timing. Use
+  # `Crypto::Subtle.constant_time_compare` instead.
+  #
+  # For example, this is considered insecure:
+  #
+  # ```
+  # signature == OpenSSL::HMAC.hexdigest(:sha256, key, data)
+  # ```
+  #
+  # And should be written as:
+  #
+  # ```
+  # Crypto::Subtle.constant_time_compare(signature, OpenSSL::HMAC.hexdigest(:sha256, key, data))
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Security/TimingAttack:
+  #   Enabled: true
+  #   DigestMethodNames:
+  #     - digest
+  #     - hexdigest
+  #     - final
+  #     - hexfinal
+  # ```
+  class TimingAttack < Base
+    properties do
+      since_version "1.7.0"
+      description "Disallows non-constant-time comparison of digests"
+      digest_method_names %w[digest hexdigest final hexfinal]
+    end
+
+    MSG = "Comparing digests with `%s` is vulnerable to timing attacks; use `Crypto::Subtle.constant_time_compare`"
+
+    COMPARISON_OPERATORS = %w[== !=]
+
+    def test(source, node : Crystal::Call)
+      return unless node.name.in?(COMPARISON_OPERATORS)
+      return unless node.args.size == 1
+      return unless digest_call?(node.obj) || digest_call?(node.args.first)
+
+      issue_for(node, MSG % node.name)
+    end
+
+    private def digest_call?(node)
+      node.is_a?(Crystal::Call) &&
+        node.name.in?(digest_method_names) &&
+        !node.obj.nil?
+    end
+  end
+end

--- a/src/ameba/rule/security/timing_attack.cr
+++ b/src/ameba/rule/security/timing_attack.cr
@@ -20,6 +20,11 @@ module Ameba::Rule::Security
   # Crypto::Subtle.constant_time_compare(signature, OpenSSL::HMAC.hexdigest(:sha256, key, data))
   # ```
   #
+  # Comparing two freshly computed digests with each other is not
+  # reported, since neither side is a stored reference value.
+  #
+  # Reference: [CWE-208](https://cwe.mitre.org/data/definitions/208.html)
+  #
   # YAML configuration example:
   #
   # ```
@@ -45,7 +50,10 @@ module Ameba::Rule::Security
     def test(source, node : Crystal::Call)
       return unless node.name.in?(COMPARISON_OPERATORS)
       return unless node.args.size == 1
-      return unless digest_call?(node.obj) || digest_call?(node.args.first)
+
+      lhs, rhs = node.obj, node.args.first
+      return unless digest_call?(lhs) || digest_call?(rhs)
+      return if digest_call?(lhs) && digest_call?(rhs)
 
       issue_for(node, MSG % node.name)
     end

--- a/src/ameba/rule/security/weak_crypto.cr
+++ b/src/ameba/rule/security/weak_crypto.cr
@@ -22,6 +22,8 @@ module Ameba::Rule::Security
   # OpenSSL::Digest.new("SHA256")
   # ```
   #
+  # Reference: [CWE-327](https://cwe.mitre.org/data/definitions/327.html)
+  #
   # YAML configuration example:
   #
   # ```

--- a/src/ameba/rule/security/weak_crypto.cr
+++ b/src/ameba/rule/security/weak_crypto.cr
@@ -1,0 +1,66 @@
+require "./base"
+
+module Ameba::Rule::Security
+  # A rule that disallows weak cryptographic hash algorithms.
+  #
+  # MD5 and SHA1 are broken for security purposes: collisions can be
+  # produced at low cost, so they must not be used for signatures,
+  # token generation or password hashing. If a weak algorithm is needed
+  # for interoperability with a legacy system, disable this rule inline.
+  #
+  # For example, these are considered insecure:
+  #
+  # ```
+  # Digest::MD5.hexdigest(payload)
+  # OpenSSL::Digest.new("SHA1")
+  # ```
+  #
+  # And should be written as:
+  #
+  # ```
+  # Digest::SHA256.hexdigest(payload)
+  # OpenSSL::Digest.new("SHA256")
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Security/WeakCrypto:
+  #   Enabled: true
+  #   WeakAlgorithms:
+  #     - MD5
+  #     - SHA1
+  # ```
+  class WeakCrypto < Base
+    properties do
+      since_version "1.7.0"
+      description "Disallows weak cryptographic hash algorithms"
+      weak_algorithms %w[MD5 SHA1]
+    end
+
+    MSG = "Weak hash algorithm `%s` is not suitable for security purposes"
+
+    DIGEST_PATH_NAME        = "Digest"
+    OPENSSL_DIGEST_PATH     = %w[OpenSSL Digest]
+    DIGEST_CONSTRUCTOR_NAME = "new"
+
+    def test(source, node : Crystal::Path)
+      names = node.names
+      return unless names.size >= 2
+      return unless names[-2] == DIGEST_PATH_NAME
+      return unless (algorithm = names.last).in?(weak_algorithms)
+
+      issue_for(node, MSG % algorithm)
+    end
+
+    def test(source, node : Crystal::Call)
+      return unless node.name == DIGEST_CONSTRUCTOR_NAME
+      return unless (obj = node.obj).is_a?(Crystal::Path)
+      return unless obj.names.last(2) == OPENSSL_DIGEST_PATH
+      return unless (arg = node.args.first?).is_a?(Crystal::StringLiteral)
+      return unless (algorithm = arg.value.upcase).in?(weak_algorithms)
+
+      issue_for(node, MSG % algorithm)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new `Security` rule group — a first step towards making Ameba useful as a security scanner for Crystal.

## Added rules

| Rule | Detects | CWE |
|---|---|---|
| `Security/CommandInjection` | Shell commands (`system`, backticks, `%x`) built from interpolated strings | [CWE-78](https://cwe.mitre.org/data/definitions/78.html) |
| `Security/SqlInjection` | SQL statements built from interpolated strings (includes heredocs, see #592) | [CWE-89](https://cwe.mitre.org/data/definitions/89.html) |
| `Security/WeakCrypto` | `Digest::MD5`, `Digest::SHA1`, `OpenSSL::Digest.new("MD5"/"SHA1")` | [CWE-327](https://cwe.mitre.org/data/definitions/327.html) |
| `Security/InsecureRandom` | `Random` used to generate tokens/secrets instead of `Random::Secure` | [CWE-338](https://cwe.mitre.org/data/definitions/338.html) |
| `Security/NoTlsVerify` | `OpenSSL::SSL::VerifyMode::NONE` | [CWE-295](https://cwe.mitre.org/data/definitions/295.html) |
| `Security/TimingAttack` | `==` / `!=` comparison of digests instead of `Crypto::Subtle.constant_time_compare` | [CWE-208](https://cwe.mitre.org/data/definitions/208.html) |
| `Security/HardcodedSecret` | Secrets in string literals: secret-named targets and well-known token formats (AWS, GitHub, Stripe, ...) | [CWE-798](https://cwe.mitre.org/data/definitions/798.html) |

## Decisions

These follow what mature tools do (Brakeman, bandit, gosec, Semgrep, CodeQL):

- **In core, not in [ameba-security](https://github.com/crystal-ameba/ameba-security).** I considered a separate shard, but all these rules only match stdlib APIs, so they belong in Ameba itself — every install gets them. Having a `Security/` group here and an `ameba-security` shard at the same time would be confusing, so that repo stays empty.
- **Extensions are organized by target library, not by category.** Framework- and shard-specific rules (Kemal, crystal-db, ...) should live in extensions like `ameba-kemal` later — the `rubocop-rails` model. Extension rules can still define themselves inside the `Security` group, so `--only Security` and group config keep working across core and extensions.
- **Precision over recall.** A noisy security rule gets disabled as a whole group. Rules skip static interpolations, recognized sanitizers (`Process.quote`, numeric casts) and placeholder values. Secret names match whole words only (`api_key` yes, `compass` no).
- **Confidence on injection rules.** Each finding gets `High` / `Medium` / `Low` confidence based on the interpolated expression (direct input read / variable / other). `MinConfidence` in the config filters findings. This lives inside the `Security` group only — core `Issue` is untouched.
- **`Error` severity by default**, like other groups have their own default.
- **Spec files are skipped.** Test fixtures are full of fake secrets and shell snippets.
- **No autocorrection.** Security fixes change behavior, so rules explain instead of rewriting.
- `Crystal::Path` was added to the visitable nodes so rules can inspect constant references (`VerifyMode::NONE`, `Digest::MD5`). Other rules are not affected.


## Notes

Happy to adjust: split this into smaller PRs, rename rules, change defaults, or ship the group as opt-in for the first release cycle.
