### PR TITLE
Cleanup redundant overrides in `AST::FlowExpressionVisitor`

### DIFF
--- a/src/ameba/ast/visitors/flow_expression_visitor.cr
+++ b/src/ameba/ast/visitors/flow_expression_visitor.cr
@@ -23,12 +23,6 @@ module Ameba::AST
     end
 
     # :nodoc:
-    def visit(node : Crystal::Call)
-      on_loop_started(node) if loop?(node)
-      true
-    end
-
-    # :nodoc:
     def visit(node : Crystal::Block)
       on_loop_started(node)
       true
@@ -37,11 +31,6 @@ module Ameba::AST
     # :nodoc:
     def end_visit(node : Crystal::While | Crystal::Until)
       on_loop_ended(node)
-    end
-
-    # :nodoc:
-    def end_visit(node : Crystal::Call)
-      on_loop_ended(node) if loop?(node)
     end
 
     # :nodoc:


### PR DESCRIPTION
Follow-up to #872